### PR TITLE
Issue 91: Support for Serializable-Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ target/
 
 scripts/java
 scripts/*.ts
-scripts/*.json
+scripts/config/*.json

--- a/scripts/additional_interfaces.json
+++ b/scripts/additional_interfaces.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Legend",
+    "implements": ["Serializable"]
+  },
+  {
+    "name": "Option",
+    "implements": ["Serializable"]
+  },
+  {
+    "name": "ComponentOption",
+    "implements": ["Serializable"]
+  },
+  {
+    "name": "StatesOptionMixin",
+    "implements": ["Serializable"]
+  },
+  {
+    "name": "ShadowOptionMixin",
+    "implements": ["Serializable"]
+  }
+]

--- a/src/main/java/org/icepear/echarts/Chart.java
+++ b/src/main/java/org/icepear/echarts/Chart.java
@@ -1,5 +1,6 @@
 package org.icepear.echarts;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,7 +12,7 @@ import org.icepear.echarts.components.visualMap.ContinousVisualMap;
 import org.icepear.echarts.origin.component.visualMap.VisualMapOption;
 import org.icepear.echarts.origin.util.SeriesOption;
 
-public abstract class Chart<T extends Chart<?, ?>, E extends SeriesOption> {
+public abstract class Chart<T extends Chart<?, ?>, E extends SeriesOption> implements Serializable {
     protected final T self;
     protected final Class<E> seriesClazz;
     protected List<Dataset> datasets;

--- a/src/main/java/org/icepear/echarts/Option.java
+++ b/src/main/java/org/icepear/echarts/Option.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts;
 
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -29,7 +31,7 @@ import org.icepear.echarts.origin.util.SeriesOption;
 
 @Accessors(chain = true)
 @Data
-public class Option implements EChartsOption {
+public class Option implements EChartsOption, Serializable {
 
     private Boolean animation;
 

--- a/src/main/java/org/icepear/echarts/components/legend/Legend.java
+++ b/src/main/java/org/icepear/echarts/components/legend/Legend.java
@@ -1,5 +1,6 @@
 package org.icepear.echarts.components.legend;
 
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +13,7 @@ import org.icepear.echarts.origin.util.LabelOption;
 
 @Accessors(chain = true)
 @Data
-public class Legend implements LegendOption {
+public class Legend implements LegendOption, Serializable {
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/origin/util/ComponentOption.java
+++ b/src/main/java/org/icepear/echarts/origin/util/ComponentOption.java
@@ -1,9 +1,11 @@
 package org.icepear.echarts.origin.util;
 
+import java.io.Serializable;
+
 /**
  * https://github.com/apache/echarts/blob/790687df55a5dbe286e52cf182c0983938efd367/src/util/types.ts#L1491
  */
-public interface ComponentOption {
+public interface ComponentOption extends Serializable {
 
     ComponentOption setMainType(String mainType);
 

--- a/src/main/java/org/icepear/echarts/origin/util/ShadowOptionMixin.java
+++ b/src/main/java/org/icepear/echarts/origin/util/ShadowOptionMixin.java
@@ -1,9 +1,11 @@
 package org.icepear.echarts.origin.util;
 
+import java.io.Serializable;
+
 /**
  * https://github.com/apache/echarts/blob/790687df55a5dbe286e52cf182c0983938efd367/src/util/types.ts#L841
  */
-public interface ShadowOptionMixin {
+public interface ShadowOptionMixin extends Serializable {
 
     ShadowOptionMixin setShadowBlur(Number shadowBlur);
 

--- a/src/main/java/org/icepear/echarts/origin/util/StatesOptionMixin.java
+++ b/src/main/java/org/icepear/echarts/origin/util/StatesOptionMixin.java
@@ -1,9 +1,11 @@
 package org.icepear.echarts.origin.util;
 
+import java.io.Serializable;
+
 /**
  * https://github.com/apache/echarts/blob/790687df55a5dbe286e52cf182c0983938efd367/src/util/types.ts#L1534
  */
-public interface StatesOptionMixin {
+public interface StatesOptionMixin extends Serializable {
 
     StatesOptionMixin setEmphasis(Object emphasis);
 


### PR DESCRIPTION
PR for https://github.com/ECharts-Java/ECharts-Java/issues/91

Since we use Apache Wicket, the model classes used must implement the Serializable Interface.

This PR provides a general option for adding the Serializable Interface to generated classes and interfaces. The config and java files can still be generated.

We have added an additional config file that can be used to define the classes and interfaces that should implement the Serializable Interface.

I know that the serialVersionUID is missing, but I'm not sure whether we need it or whether a complex logic should be implemented here, which also applies to all classes that implement an interface with Serializable, the serialVersionUID?

Also we configured some classes / interfaces which have to implement serializable interface for our purpose.

Or is it more effective if all Java classes implement the Serializable Interface? Then you wouldn't have to specify the classes explicitly?

What do you think?