### PR TITLE
Support for Serializable-Interface

### DIFF
--- a/scripts/config-to-java.py
+++ b/scripts/config-to-java.py
@@ -71,6 +71,18 @@ symbol_table = {
         "import": "lombok.Setter",
         "builtin": True,
         "obj": None
+    },
+    "Serializable": {
+        "path": None,
+        "import": "java.io.Serializable",
+        "builtin": True,
+        "obj": None
+    },
+    "Serial": {
+        "path": None,
+        "import": "java.io.Serial",
+        "builtin": True,
+        "obj": None
     }
 }
 
@@ -176,11 +188,13 @@ def generate_annotation_lines(lines):
 
 
 def generate_class_start_line(obj, lines):
-    if len(obj["implements"]) == 0:
-        lines.append("public class {} {{\n".format(obj["name"]))
-    else:
-        lines.append("public class {} implements {} {{\n".format(
-            obj["name"], ", ".join(obj["implements"])))
+    implements = list(obj["implements"])
+    if "Serializable" not in implements:
+        implements.append("Serializable")
+
+    lines.append("public class {} implements {} {{\n".format(obj["name"], ", ".join(implements)))
+    lines.append("\n    @Serial")
+    lines.append("\n    private static final long serialVersionUID = 1L;\n")
 
 
 def generate_interface_start_line(obj, lines):
@@ -290,7 +304,7 @@ def generate_class(info):
     symbols = get_symbols_dfs(obj)
     fields, defaults = get_fields_dfs(obj)
     eliminate_fields_conflicts(fields)
-    symbols |= {"Accessors", "Data"}
+    symbols |= {"Accessors", "Data", "Serial", "Serializable"}
     lines = []
     generate_package_line(info, lines)
     generate_import_lines(info, symbols, fields, lines)

--- a/scripts/config-to-java.py
+++ b/scripts/config-to-java.py
@@ -77,12 +77,6 @@ symbol_table = {
         "import": "java.io.Serializable",
         "builtin": True,
         "obj": None
-    },
-    "Serial": {
-        "path": None,
-        "import": "java.io.Serial",
-        "builtin": True,
-        "obj": None
     }
 }
 
@@ -193,7 +187,6 @@ def generate_class_start_line(obj, lines):
         implements.append("Serializable")
 
     lines.append("public class {} implements {} {{\n".format(obj["name"], ", ".join(implements)))
-    lines.append("\n    @Serial")
     lines.append("\n    private static final long serialVersionUID = 1L;\n")
 
 
@@ -304,7 +297,7 @@ def generate_class(info):
     symbols = get_symbols_dfs(obj)
     fields, defaults = get_fields_dfs(obj)
     eliminate_fields_conflicts(fields)
-    symbols |= {"Accessors", "Data", "Serial", "Serializable"}
+    symbols |= {"Accessors", "Data", "Serializable"}
     lines = []
     generate_package_line(info, lines)
     generate_import_lines(info, symbols, fields, lines)

--- a/src/main/java/org/icepear/echarts/Bar.java
+++ b/src/main/java/org/icepear/echarts/Bar.java
@@ -2,10 +2,12 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.bar.BarSeries;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class Bar extends CartesianCoordChart<Bar, BarSeries> implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public Bar() {

--- a/src/main/java/org/icepear/echarts/Bar.java
+++ b/src/main/java/org/icepear/echarts/Bar.java
@@ -2,7 +2,12 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.bar.BarSeries;
 
-public class Bar extends CartesianCoordChart<Bar, BarSeries> {
+import java.io.Serializable;
+
+public class Bar extends CartesianCoordChart<Bar, BarSeries> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     public Bar() {
         super(Bar.class, BarSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Bar.java
+++ b/src/main/java/org/icepear/echarts/Bar.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.bar.BarSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Bar extends CartesianCoordChart<Bar, BarSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Bar() {

--- a/src/main/java/org/icepear/echarts/Boxplot.java
+++ b/src/main/java/org/icepear/echarts/Boxplot.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.boxplot.BoxplotSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Boxplot extends CartesianCoordChart<Boxplot, BoxplotSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Boxplot() {

--- a/src/main/java/org/icepear/echarts/Boxplot.java
+++ b/src/main/java/org/icepear/echarts/Boxplot.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.boxplot.BoxplotSeries;
 
-public class Boxplot extends CartesianCoordChart<Boxplot, BoxplotSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Boxplot extends CartesianCoordChart<Boxplot, BoxplotSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Boxplot() {
         super(Boxplot.class, BoxplotSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Candlestick.java
+++ b/src/main/java/org/icepear/echarts/Candlestick.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.candlestick.CandlestickSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Candlestick extends CartesianCoordChart<Candlestick, CandlestickSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Candlestick() {

--- a/src/main/java/org/icepear/echarts/Candlestick.java
+++ b/src/main/java/org/icepear/echarts/Candlestick.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.candlestick.CandlestickSeries;
 
-public class Candlestick extends CartesianCoordChart<Candlestick, CandlestickSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Candlestick extends CartesianCoordChart<Candlestick, CandlestickSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Candlestick() {
         super(Candlestick.class, CandlestickSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/CartesianCoordChart.java
+++ b/src/main/java/org/icepear/echarts/CartesianCoordChart.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,7 +12,11 @@ import org.icepear.echarts.components.coord.cartesian.ValueAxis;
 import org.icepear.echarts.origin.coord.cartesian.AxisOption;
 import org.icepear.echarts.origin.util.SeriesOption;
 
-public abstract class CartesianCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> {
+public abstract class CartesianCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     protected List<AxisOption> xAxes;
     protected List<AxisOption> yAxes;
 

--- a/src/main/java/org/icepear/echarts/CartesianCoordChart.java
+++ b/src/main/java/org/icepear/echarts/CartesianCoordChart.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesOption;
 
 public abstract class CartesianCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     protected List<AxisOption> xAxes;

--- a/src/main/java/org/icepear/echarts/Chart.java
+++ b/src/main/java/org/icepear/echarts/Chart.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,7 +13,11 @@ import org.icepear.echarts.components.visualMap.ContinousVisualMap;
 import org.icepear.echarts.origin.component.visualMap.VisualMapOption;
 import org.icepear.echarts.origin.util.SeriesOption;
 
-public abstract class Chart<T extends Chart<?, ?>, E extends SeriesOption> {
+public abstract class Chart<T extends Chart<?, ?>, E extends SeriesOption> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     protected final T self;
     protected final Class<E> seriesClazz;
     protected List<Dataset> datasets;

--- a/src/main/java/org/icepear/echarts/Chart.java
+++ b/src/main/java/org/icepear/echarts/Chart.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.SeriesOption;
 
 public abstract class Chart<T extends Chart<?, ?>, E extends SeriesOption> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     protected final T self;

--- a/src/main/java/org/icepear/echarts/Funnel.java
+++ b/src/main/java/org/icepear/echarts/Funnel.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.funnel.FunnelSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Funnel extends Chart<Funnel, FunnelSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Funnel() {

--- a/src/main/java/org/icepear/echarts/Funnel.java
+++ b/src/main/java/org/icepear/echarts/Funnel.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.funnel.FunnelSeries;
 
-public class Funnel extends Chart<Funnel, FunnelSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Funnel extends Chart<Funnel, FunnelSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Funnel() {
         super(Funnel.class, FunnelSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Gauge.java
+++ b/src/main/java/org/icepear/echarts/Gauge.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.gauge.GaugeSeries;
 
-public class Gauge extends Chart<Gauge, GaugeSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Gauge extends Chart<Gauge, GaugeSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Gauge() {
         super(Gauge.class, GaugeSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Gauge.java
+++ b/src/main/java/org/icepear/echarts/Gauge.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.gauge.GaugeSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Gauge extends Chart<Gauge, GaugeSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Gauge() {

--- a/src/main/java/org/icepear/echarts/Graph.java
+++ b/src/main/java/org/icepear/echarts/Graph.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.graph.GraphSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Graph extends Chart<Graph, GraphSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Graph() {

--- a/src/main/java/org/icepear/echarts/Graph.java
+++ b/src/main/java/org/icepear/echarts/Graph.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.graph.GraphSeries;
 
-public class Graph extends Chart<Graph, GraphSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Graph extends Chart<Graph, GraphSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Graph() {
         super(Graph.class, GraphSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Heatmap.java
+++ b/src/main/java/org/icepear/echarts/Heatmap.java
@@ -5,7 +5,14 @@ import org.icepear.echarts.components.coord.SplitArea;
 import org.icepear.echarts.components.coord.cartesian.CategoryAxis;
 import org.icepear.echarts.components.coord.cartesian.ValueAxis;
 
-public class Heatmap extends CartesianCoordChart<Heatmap, HeatmapSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Heatmap extends CartesianCoordChart<Heatmap, HeatmapSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Heatmap() {
         super(Heatmap.class, HeatmapSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Heatmap.java
+++ b/src/main/java/org/icepear/echarts/Heatmap.java
@@ -5,12 +5,10 @@ import org.icepear.echarts.components.coord.SplitArea;
 import org.icepear.echarts.components.coord.cartesian.CategoryAxis;
 import org.icepear.echarts.components.coord.cartesian.ValueAxis;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Heatmap extends CartesianCoordChart<Heatmap, HeatmapSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Heatmap() {

--- a/src/main/java/org/icepear/echarts/Line.java
+++ b/src/main/java/org/icepear/echarts/Line.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.line.LineSeries;
 
-public class Line extends CartesianCoordChart<Line, LineSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Line extends CartesianCoordChart<Line, LineSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Line() {
         super(Line.class, LineSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Line.java
+++ b/src/main/java/org/icepear/echarts/Line.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.line.LineSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Line extends CartesianCoordChart<Line, LineSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Line() {

--- a/src/main/java/org/icepear/echarts/Option.java
+++ b/src/main/java/org/icepear/echarts/Option.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -29,7 +32,10 @@ import org.icepear.echarts.origin.util.SeriesOption;
 
 @Accessors(chain = true)
 @Data
-public class Option implements EChartsOption {
+public class Option implements EChartsOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean animation;
 

--- a/src/main/java/org/icepear/echarts/Option.java
+++ b/src/main/java/org/icepear/echarts/Option.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -34,7 +33,6 @@ import org.icepear.echarts.origin.util.SeriesOption;
 @Data
 public class Option implements EChartsOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean animation;

--- a/src/main/java/org/icepear/echarts/Parallel.java
+++ b/src/main/java/org/icepear/echarts/Parallel.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.parallel.ParallelSeries;
 
-public class Parallel extends ParallelCoordChart<Parallel, ParallelSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Parallel extends ParallelCoordChart<Parallel, ParallelSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Parallel() {
         super(Parallel.class, ParallelSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Parallel.java
+++ b/src/main/java/org/icepear/echarts/Parallel.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.parallel.ParallelSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Parallel extends ParallelCoordChart<Parallel, ParallelSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Parallel() {

--- a/src/main/java/org/icepear/echarts/ParallelCoordChart.java
+++ b/src/main/java/org/icepear/echarts/ParallelCoordChart.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,7 +12,11 @@ import org.icepear.echarts.components.coord.parallel.ValueParallelAxis;
 import org.icepear.echarts.origin.coord.parallel.ParallelAxisOption;
 import org.icepear.echarts.origin.util.SeriesOption;
 
-public abstract class ParallelCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> {
+public abstract class ParallelCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     protected List<ParallelAxisOption> parallelAxes;
 
     public ParallelCoordChart(final Class<T> clazz, final Class<E> seriesClazz) {

--- a/src/main/java/org/icepear/echarts/ParallelCoordChart.java
+++ b/src/main/java/org/icepear/echarts/ParallelCoordChart.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesOption;
 
 public abstract class ParallelCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     protected List<ParallelAxisOption> parallelAxes;

--- a/src/main/java/org/icepear/echarts/Pie.java
+++ b/src/main/java/org/icepear/echarts/Pie.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.pie.PieSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Pie extends Chart<Pie, PieSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Pie() {

--- a/src/main/java/org/icepear/echarts/Pie.java
+++ b/src/main/java/org/icepear/echarts/Pie.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.pie.PieSeries;
 
-public class Pie extends Chart<Pie, PieSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Pie extends Chart<Pie, PieSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Pie() {
         super(Pie.class, PieSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/PolarBar.java
+++ b/src/main/java/org/icepear/echarts/PolarBar.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.bar.BarSeries;
 
-public class PolarBar extends PolarCoordChart<PolarBar, BarSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class PolarBar extends PolarCoordChart<PolarBar, BarSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public PolarBar() {
         super(PolarBar.class, BarSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/PolarBar.java
+++ b/src/main/java/org/icepear/echarts/PolarBar.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.bar.BarSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class PolarBar extends PolarCoordChart<PolarBar, BarSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public PolarBar() {

--- a/src/main/java/org/icepear/echarts/PolarCoordChart.java
+++ b/src/main/java/org/icepear/echarts/PolarCoordChart.java
@@ -9,7 +9,14 @@ import org.icepear.echarts.origin.coord.polar.AngleAxisOption;
 import org.icepear.echarts.origin.coord.polar.RadiusAxisOption;
 import org.icepear.echarts.origin.util.SeriesOption;
 
-public abstract class PolarCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public abstract class PolarCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E>  implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public PolarCoordChart(final Class<T> clazz, final Class<E> seriesClazz) {
         super(clazz, seriesClazz);
         option.setPolar(new PolarAxis());

--- a/src/main/java/org/icepear/echarts/PolarCoordChart.java
+++ b/src/main/java/org/icepear/echarts/PolarCoordChart.java
@@ -9,12 +9,10 @@ import org.icepear.echarts.origin.coord.polar.AngleAxisOption;
 import org.icepear.echarts.origin.coord.polar.RadiusAxisOption;
 import org.icepear.echarts.origin.util.SeriesOption;
 
-import java.io.Serial;
 import java.io.Serializable;
 
-public abstract class PolarCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E>  implements Serializable {
+public abstract class PolarCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public PolarCoordChart(final Class<T> clazz, final Class<E> seriesClazz) {

--- a/src/main/java/org/icepear/echarts/PolarLine.java
+++ b/src/main/java/org/icepear/echarts/PolarLine.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.line.LineSeries;
 
-public class PolarLine extends PolarCoordChart<PolarLine, LineSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class PolarLine extends PolarCoordChart<PolarLine, LineSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public PolarLine() {
         super(PolarLine.class, LineSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/PolarLine.java
+++ b/src/main/java/org/icepear/echarts/PolarLine.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.line.LineSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class PolarLine extends PolarCoordChart<PolarLine, LineSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public PolarLine() {

--- a/src/main/java/org/icepear/echarts/PolarScatter.java
+++ b/src/main/java/org/icepear/echarts/PolarScatter.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.scatter.ScatterSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class PolarScatter extends PolarCoordChart<PolarScatter, ScatterSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public PolarScatter() {

--- a/src/main/java/org/icepear/echarts/PolarScatter.java
+++ b/src/main/java/org/icepear/echarts/PolarScatter.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.scatter.ScatterSeries;
 
-public class PolarScatter extends PolarCoordChart<PolarScatter, ScatterSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class PolarScatter extends PolarCoordChart<PolarScatter, ScatterSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public PolarScatter() {
         super(PolarScatter.class, ScatterSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Radar.java
+++ b/src/main/java/org/icepear/echarts/Radar.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.radar.RadarSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Radar extends RadarCoordChart<Radar, RadarSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Radar() {

--- a/src/main/java/org/icepear/echarts/Radar.java
+++ b/src/main/java/org/icepear/echarts/Radar.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.radar.RadarSeries;
 
-public class Radar extends RadarCoordChart<Radar, RadarSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Radar extends RadarCoordChart<Radar, RadarSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Radar() {
         super(Radar.class, RadarSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/RadarCoordChart.java
+++ b/src/main/java/org/icepear/echarts/RadarCoordChart.java
@@ -4,12 +4,10 @@ import org.icepear.echarts.components.coord.radar.RadarAxis;
 import org.icepear.echarts.components.coord.radar.RadarIndicator;
 import org.icepear.echarts.origin.util.SeriesOption;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public abstract class RadarCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public RadarCoordChart(final Class<T> clazz, final Class<E> seriesClazz) {

--- a/src/main/java/org/icepear/echarts/RadarCoordChart.java
+++ b/src/main/java/org/icepear/echarts/RadarCoordChart.java
@@ -4,7 +4,14 @@ import org.icepear.echarts.components.coord.radar.RadarAxis;
 import org.icepear.echarts.components.coord.radar.RadarIndicator;
 import org.icepear.echarts.origin.util.SeriesOption;
 
-public abstract class RadarCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public abstract class RadarCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public RadarCoordChart(final Class<T> clazz, final Class<E> seriesClazz) {
         super(clazz, seriesClazz);
     }

--- a/src/main/java/org/icepear/echarts/Sankey.java
+++ b/src/main/java/org/icepear/echarts/Sankey.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.sankey.SankeySeries;
 
-public class Sankey extends Chart<Sankey, SankeySeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Sankey extends Chart<Sankey, SankeySeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Sankey() {
         super(Sankey.class, SankeySeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Sankey.java
+++ b/src/main/java/org/icepear/echarts/Sankey.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.sankey.SankeySeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Sankey extends Chart<Sankey, SankeySeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Sankey() {

--- a/src/main/java/org/icepear/echarts/Scatter.java
+++ b/src/main/java/org/icepear/echarts/Scatter.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.scatter.ScatterSeries;
 
-public class Scatter extends CartesianCoordChart<Scatter, ScatterSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Scatter extends CartesianCoordChart<Scatter, ScatterSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Scatter() {
         super(Scatter.class, ScatterSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Scatter.java
+++ b/src/main/java/org/icepear/echarts/Scatter.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.scatter.ScatterSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Scatter extends CartesianCoordChart<Scatter, ScatterSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Scatter() {

--- a/src/main/java/org/icepear/echarts/SingleCoordChart.java
+++ b/src/main/java/org/icepear/echarts/SingleCoordChart.java
@@ -3,7 +3,14 @@ package org.icepear.echarts;
 import org.icepear.echarts.origin.coord.single.SingleAxisOption;
 import org.icepear.echarts.origin.util.SeriesOption;
 
-public abstract class SingleCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public abstract class SingleCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public SingleCoordChart(final Class<T> clazz, final Class<E> seriesClazz) {
         super(clazz, seriesClazz);
     }

--- a/src/main/java/org/icepear/echarts/SingleCoordChart.java
+++ b/src/main/java/org/icepear/echarts/SingleCoordChart.java
@@ -3,12 +3,10 @@ package org.icepear.echarts;
 import org.icepear.echarts.origin.coord.single.SingleAxisOption;
 import org.icepear.echarts.origin.util.SeriesOption;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public abstract class SingleCoordChart<T extends Chart<?, ?>, E extends SeriesOption> extends Chart<T, E> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public SingleCoordChart(final Class<T> clazz, final Class<E> seriesClazz) {

--- a/src/main/java/org/icepear/echarts/Sunburst.java
+++ b/src/main/java/org/icepear/echarts/Sunburst.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.sunburst.SunburstSeries;
 
-public class Sunburst extends Chart<Sunburst, SunburstSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Sunburst extends Chart<Sunburst, SunburstSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Sunburst() {
         super(Sunburst.class, SunburstSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Sunburst.java
+++ b/src/main/java/org/icepear/echarts/Sunburst.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.sunburst.SunburstSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Sunburst extends Chart<Sunburst, SunburstSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Sunburst() {

--- a/src/main/java/org/icepear/echarts/ThemeRiver.java
+++ b/src/main/java/org/icepear/echarts/ThemeRiver.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.themeRiver.ThemeRiverSeries;
 
-public class ThemeRiver extends SingleCoordChart<ThemeRiver, ThemeRiverSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class ThemeRiver extends SingleCoordChart<ThemeRiver, ThemeRiverSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public ThemeRiver() {
         super(ThemeRiver.class, ThemeRiverSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/ThemeRiver.java
+++ b/src/main/java/org/icepear/echarts/ThemeRiver.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.themeRiver.ThemeRiverSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class ThemeRiver extends SingleCoordChart<ThemeRiver, ThemeRiverSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public ThemeRiver() {

--- a/src/main/java/org/icepear/echarts/Tree.java
+++ b/src/main/java/org/icepear/echarts/Tree.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.tree.TreeSeries;
 
-public class Tree extends Chart<Tree, TreeSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Tree extends Chart<Tree, TreeSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Tree() {
         super(Tree.class, TreeSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Tree.java
+++ b/src/main/java/org/icepear/echarts/Tree.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.tree.TreeSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Tree extends Chart<Tree, TreeSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Tree() {

--- a/src/main/java/org/icepear/echarts/Treemap.java
+++ b/src/main/java/org/icepear/echarts/Treemap.java
@@ -2,7 +2,14 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.treemap.TreemapSeries;
 
-public class Treemap extends Chart<Treemap, TreemapSeries> {
+import java.io.Serial;
+import java.io.Serializable;
+
+public class Treemap extends Chart<Treemap, TreemapSeries> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public Treemap() {
         super(Treemap.class, TreemapSeries.class);
     }

--- a/src/main/java/org/icepear/echarts/Treemap.java
+++ b/src/main/java/org/icepear/echarts/Treemap.java
@@ -2,12 +2,10 @@ package org.icepear.echarts;
 
 import org.icepear.echarts.charts.treemap.TreemapSeries;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 public class Treemap extends Chart<Treemap, TreemapSeries> implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     public Treemap() {
@@ -18,5 +16,5 @@ public class Treemap extends Chart<Treemap, TreemapSeries> implements Serializab
     public TreemapSeries createSeries() {
         return new TreemapSeries().setType("treemap");
     }
-    
+
 }

--- a/src/main/java/org/icepear/echarts/charts/bar/BarBackgroundStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarBackgroundStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.bar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.DecalObject;
 @Data
 public class BarBackgroundStyle implements BarBackgroundStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/bar/BarBackgroundStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarBackgroundStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.bar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.DecalObject;
 
 @Accessors(chain = true)
 @Data
-public class BarBackgroundStyle implements BarBackgroundStyleOption {
+public class BarBackgroundStyle implements BarBackgroundStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/bar/BarDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.bar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.chart.bar.BarLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class BarDataItem implements BarDataItemOption {
+public class BarDataItem implements BarDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private BarItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/bar/BarDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.bar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.chart.bar.BarLabelOption;
 @Data
 public class BarDataItem implements BarDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private BarItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/bar/BarEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.bar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.chart.bar.BarLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class BarEmphasis implements BarEmphasisOption {
+public class BarEmphasis implements BarEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String focus;
 

--- a/src/main/java/org/icepear/echarts/charts/bar/BarEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.bar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.chart.bar.BarLabelOption;
 @Data
 public class BarEmphasis implements BarEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String focus;

--- a/src/main/java/org/icepear/echarts/charts/bar/BarItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarItemStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.bar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.DecalObject;
 
 @Accessors(chain = true)
 @Data
-public class BarItemStyle implements BarItemStyleOption {
+public class BarItemStyle implements BarItemStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/bar/BarItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarItemStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.bar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.DecalObject;
 @Data
 public class BarItemStyle implements BarItemStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/bar/BarLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.bar;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class BarLabel implements BarLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/bar/BarLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.bar;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class BarLabel implements BarLabelOption {
+public class BarLabel implements BarLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/bar/BarSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.bar;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -26,7 +25,6 @@ import org.icepear.echarts.origin.util.OptionEncode;
 @Data
 public class BarSeries implements BarSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/bar/BarSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/bar/BarSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.bar;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -22,7 +24,10 @@ import org.icepear.echarts.origin.util.OptionEncode;
 
 @Accessors(chain = true)
 @Data
-public class BarSeries implements BarSeriesOption {
+public class BarSeries implements BarSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.boxplot;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class BoxplotDataItem implements BoxplotDataItemOption {
+public class BoxplotDataItem implements BoxplotDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.boxplot;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class BoxplotDataItem implements BoxplotDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.boxplot;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class BoxplotEmphasis implements BoxplotEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.boxplot;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class BoxplotEmphasis implements BoxplotEmphasisOption {
+public class BoxplotEmphasis implements BoxplotEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.boxplot;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -25,7 +24,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class BoxplotSeries implements BoxplotSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.boxplot;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -21,7 +23,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class BoxplotSeries implements BoxplotSeriesOption {
+public class BoxplotSeries implements BoxplotSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotTransform.java
+++ b/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotTransform.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.boxplot;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.data.helper.DataTransformConfigOption;
 @Data
 public class BoxplotTransform implements BoxplotTransformOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String type = "boxplot";

--- a/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotTransform.java
+++ b/src/main/java/org/icepear/echarts/charts/boxplot/BoxplotTransform.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.boxplot;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.data.helper.DataTransformConfigOption;
 
 @Accessors(chain = true)
 @Data
-public class BoxplotTransform implements BoxplotTransformOption {
+public class BoxplotTransform implements BoxplotTransformOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String type = "boxplot";
 

--- a/src/main/java/org/icepear/echarts/charts/boxplot/PrepareBoxplotData.java
+++ b/src/main/java/org/icepear/echarts/charts/boxplot/PrepareBoxplotData.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.boxplot;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.chart.boxplot.PrepareBoxplotDataOption;
 @Data
 public class PrepareBoxplotData implements PrepareBoxplotDataOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/charts/boxplot/PrepareBoxplotData.java
+++ b/src/main/java/org/icepear/echarts/charts/boxplot/PrepareBoxplotData.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.boxplot;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.chart.boxplot.PrepareBoxplotDataOption;
 
 @Accessors(chain = true)
 @Data
-public class PrepareBoxplotData implements PrepareBoxplotDataOption {
+public class PrepareBoxplotData implements PrepareBoxplotDataOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object boundIQR;

--- a/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.candlestick;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class CandlestickDataItem implements CandlestickDataItemOption {
+public class CandlestickDataItem implements CandlestickDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private CandlestickItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.candlestick;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class CandlestickDataItem implements CandlestickDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private CandlestickItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.candlestick;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class CandlestickEmphasis implements CandlestickEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private CandlestickItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.candlestick;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class CandlestickEmphasis implements CandlestickEmphasisOption {
+public class CandlestickEmphasis implements CandlestickEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private CandlestickItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickItemStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.candlestick;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.DecalObject;
 @Data
 public class CandlestickItemStyle implements CandlestickItemStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickItemStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.candlestick;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.DecalObject;
 
 @Accessors(chain = true)
 @Data
-public class CandlestickItemStyle implements CandlestickItemStyleOption {
+public class CandlestickItemStyle implements CandlestickItemStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.candlestick;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -25,7 +24,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class CandlestickSeries implements CandlestickSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/candlestick/CandlestickSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.candlestick;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -21,7 +23,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class CandlestickSeries implements CandlestickSeriesOption {
+public class CandlestickSeries implements CandlestickSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/funnel/FunnelDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/funnel/FunnelDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.funnel;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 @Data
 public class FunnelDataItem implements FunnelDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/charts/funnel/FunnelDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/funnel/FunnelDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.funnel;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class FunnelDataItem implements FunnelDataItemOption {
+public class FunnelDataItem implements FunnelDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/funnel/FunnelEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/funnel/FunnelEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.funnel;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 @Data
 public class FunnelEmphasis implements FunnelEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String focus;

--- a/src/main/java/org/icepear/echarts/charts/funnel/FunnelEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/funnel/FunnelEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.funnel;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class FunnelEmphasis implements FunnelEmphasisOption {
+public class FunnelEmphasis implements FunnelEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String focus;
 

--- a/src/main/java/org/icepear/echarts/charts/funnel/FunnelLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/funnel/FunnelLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.funnel;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class FunnelLabel implements FunnelLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/funnel/FunnelLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/funnel/FunnelLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.funnel;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class FunnelLabel implements FunnelLabelOption {
+public class FunnelLabel implements FunnelLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/funnel/FunnelSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/funnel/FunnelSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.funnel;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -25,7 +24,6 @@ import org.icepear.echarts.origin.util.OptionEncode;
 @Data
 public class FunnelSeries implements FunnelSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/funnel/FunnelSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/funnel/FunnelSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.funnel;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -21,7 +23,10 @@ import org.icepear.echarts.origin.util.OptionEncode;
 
 @Accessors(chain = true)
 @Data
-public class FunnelSeries implements FunnelSeriesOption {
+public class FunnelSeries implements FunnelSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeAnchor.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeAnchor.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.gauge;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 @Data
 public class GaugeAnchor implements GaugeAnchorOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeAnchor.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeAnchor.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.gauge;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class GaugeAnchor implements GaugeAnchorOption {
+public class GaugeAnchor implements GaugeAnchorOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.gauge;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -17,7 +16,6 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 @Data
 public class GaugeDataItem implements GaugeDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.gauge;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -12,7 +15,10 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class GaugeDataItem implements GaugeDataItemOption {
+public class GaugeDataItem implements GaugeDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeDetail.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeDetail.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.gauge;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class GaugeDetail implements GaugeDetailOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeDetail.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeDetail.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.gauge;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class GaugeDetail implements GaugeDetailOption {
+public class GaugeDetail implements GaugeDetailOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.gauge;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -13,7 +12,6 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 @Data
 public class GaugeEmphasis implements GaugeEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String focus;

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.gauge;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -8,7 +11,10 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class GaugeEmphasis implements GaugeEmphasisOption {
+public class GaugeEmphasis implements GaugeEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String focus;
 

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugePointer.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugePointer.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.gauge;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 @Data
 public class GaugePointer implements GaugePointerOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String icon;

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugePointer.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugePointer.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.gauge;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class GaugePointer implements GaugePointerOption {
+public class GaugePointer implements GaugePointerOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String icon;
 

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeProgress.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeProgress.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.gauge;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -8,7 +11,10 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class GaugeProgress implements GaugeProgressOption {
+public class GaugeProgress implements GaugeProgressOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeProgress.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeProgress.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.gauge;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -13,7 +12,6 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 @Data
 public class GaugeProgress implements GaugeProgressOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.gauge;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import org.icepear.echarts.origin.util.OptionEncode;
 @Data
 public class GaugeSeries implements GaugeSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.gauge;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -25,7 +27,10 @@ import org.icepear.echarts.origin.util.OptionEncode;
 
 @Accessors(chain = true)
 @Data
-public class GaugeSeries implements GaugeSeriesOption {
+public class GaugeSeries implements GaugeSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeTitle.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeTitle.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.gauge;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class GaugeTitle implements GaugeTitleOption {
+public class GaugeTitle implements GaugeTitleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/gauge/GaugeTitle.java
+++ b/src/main/java/org/icepear/echarts/charts/gauge/GaugeTitle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.gauge;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class GaugeTitle implements GaugeTitleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphCategoryItem.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphCategoryItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.graph;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class GraphCategoryItem implements GraphCategoryItemOption {
+public class GraphCategoryItem implements GraphCategoryItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String symbol;
 

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphCategoryItem.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphCategoryItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.graph;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class GraphCategoryItem implements GraphCategoryItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String symbol;

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphCircular.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphCircular.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.graph;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -12,7 +11,6 @@ import org.icepear.echarts.origin.chart.graph.GraphCircularOption;
 @Data
 public class GraphCircular implements GraphCircularOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean rotateLabel;

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphCircular.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphCircular.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.graph;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -7,7 +10,10 @@ import org.icepear.echarts.origin.chart.graph.GraphCircularOption;
 
 @Accessors(chain = true)
 @Data
-public class GraphCircular implements GraphCircularOption {
+public class GraphCircular implements GraphCircularOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean rotateLabel;
 }

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphEdgeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphEdgeItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.graph;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.SeriesLineLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class GraphEdgeItem implements GraphEdgeItemOption {
+public class GraphEdgeItem implements GraphEdgeItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private GraphEdgeLineStyleOption lineStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphEdgeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphEdgeItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.graph;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.SeriesLineLabelOption;
 @Data
 public class GraphEdgeItem implements GraphEdgeItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private GraphEdgeLineStyleOption lineStyle;

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphEdgeLineStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphEdgeLineStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.graph;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -12,7 +11,6 @@ import org.icepear.echarts.origin.chart.graph.GraphEdgeLineStyleOption;
 @Data
 public class GraphEdgeLineStyle implements GraphEdgeLineStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphEdgeLineStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphEdgeLineStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.graph;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -7,7 +10,10 @@ import org.icepear.echarts.origin.chart.graph.GraphEdgeLineStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class GraphEdgeLineStyle implements GraphEdgeLineStyleOption {
+public class GraphEdgeLineStyle implements GraphEdgeLineStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.graph;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class GraphEmphasis implements GraphEmphasisOption {
+public class GraphEmphasis implements GraphEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Object blurScope;
 

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.graph;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class GraphEmphasis implements GraphEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Object blurScope;

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphForce.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphForce.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.graph;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.chart.graph.GraphForceOption;
 
 @Accessors(chain = true)
 @Data
-public class GraphForce implements GraphForceOption {
+public class GraphForce implements GraphForceOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String initLayout;
 

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphForce.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphForce.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.graph;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.chart.graph.GraphForceOption;
 @Data
 public class GraphForce implements GraphForceOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String initLayout;

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphNodeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphNodeItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.graph;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class GraphNodeItem implements GraphNodeItemOption {
+public class GraphNodeItem implements GraphNodeItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String symbol;
 

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphNodeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphNodeItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.graph;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class GraphNodeItem implements GraphNodeItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String symbol;

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.graph;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -28,7 +30,10 @@ import org.icepear.echarts.origin.util.SeriesLineLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class GraphSeries implements GraphSeriesOption {
+public class GraphSeries implements GraphSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/graph/GraphSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/graph/GraphSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.graph;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -32,7 +31,6 @@ import org.icepear.echarts.origin.util.SeriesLineLabelOption;
 @Data
 public class GraphSeries implements GraphSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.heatmap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class HeatmapDataItem implements HeatmapDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.heatmap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class HeatmapDataItem implements HeatmapDataItemOption {
+public class HeatmapDataItem implements HeatmapDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.heatmap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class HeatmapEmphasis implements HeatmapEmphasisOption {
+public class HeatmapEmphasis implements HeatmapEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String focus;
 

--- a/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.heatmap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class HeatmapEmphasis implements HeatmapEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String focus;

--- a/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.heatmap;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -25,7 +24,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class HeatmapSeries implements HeatmapSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/heatmap/HeatmapSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.heatmap;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -21,7 +23,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class HeatmapSeries implements HeatmapSeriesOption {
+public class HeatmapSeries implements HeatmapSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/line/LineAreaStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/line/LineAreaStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.line;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -7,7 +10,10 @@ import org.icepear.echarts.origin.chart.line.LineAreaStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class LineAreaStyle implements LineAreaStyleOption {
+public class LineAreaStyle implements LineAreaStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/line/LineAreaStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/line/LineAreaStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.line;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -12,7 +11,6 @@ import org.icepear.echarts.origin.chart.line.LineAreaStyleOption;
 @Data
 public class LineAreaStyle implements LineAreaStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/line/LineDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/line/LineDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.line;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class LineDataItem implements LineDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String symbol;

--- a/src/main/java/org/icepear/echarts/charts/line/LineDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/line/LineDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.line;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class LineDataItem implements LineDataItemOption {
+public class LineDataItem implements LineDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String symbol;
 

--- a/src/main/java/org/icepear/echarts/charts/line/LineEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/line/LineEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.line;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -18,7 +17,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class LineEmphasis implements LineEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/line/LineEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/line/LineEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.line;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -13,7 +16,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class LineEmphasis implements LineEmphasisOption {
+public class LineEmphasis implements LineEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/line/LineSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/line/LineSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.line;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -27,7 +26,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class LineSeries implements LineSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/line/LineSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/line/LineSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.line;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -23,7 +25,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class LineSeries implements LineSeriesOption {
+public class LineSeries implements LineSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/parallel/ParallelDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/parallel/ParallelDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.parallel;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class ParallelDataItem implements ParallelDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private LineStyleOption lineStyle;

--- a/src/main/java/org/icepear/echarts/charts/parallel/ParallelDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/parallel/ParallelDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.parallel;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class ParallelDataItem implements ParallelDataItemOption {
+public class ParallelDataItem implements ParallelDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private LineStyleOption lineStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/parallel/ParallelEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/parallel/ParallelEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.parallel;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class ParallelEmphasis implements ParallelEmphasisOption {
+public class ParallelEmphasis implements ParallelEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String focus;
 

--- a/src/main/java/org/icepear/echarts/charts/parallel/ParallelEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/parallel/ParallelEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.parallel;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class ParallelEmphasis implements ParallelEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String focus;

--- a/src/main/java/org/icepear/echarts/charts/parallel/ParallelSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/parallel/ParallelSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.parallel;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -22,7 +24,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class ParallelSeries implements ParallelSeriesOption {
+public class ParallelSeries implements ParallelSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/parallel/ParallelSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/parallel/ParallelSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.parallel;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -26,7 +25,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class ParallelSeries implements ParallelSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/pie/PieDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.pie;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.chart.pie.PieLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class PieDataItem implements PieDataItemOption {
+public class PieDataItem implements PieDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object id;

--- a/src/main/java/org/icepear/echarts/charts/pie/PieDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.pie;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.chart.pie.PieLabelOption;
 @Data
 public class PieDataItem implements PieDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/charts/pie/PieEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.pie;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.chart.pie.PieLabelOption;
 @Data
 public class PieEmphasis implements PieEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private PieItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/pie/PieEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.pie;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.chart.pie.PieLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class PieEmphasis implements PieEmphasisOption {
+public class PieEmphasis implements PieEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private PieItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/pie/PieItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieItemStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.pie;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.DecalObject;
 
 @Accessors(chain = true)
 @Data
-public class PieItemStyle implements PieItemStyleOption {
+public class PieItemStyle implements PieItemStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/pie/PieItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieItemStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.pie;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.DecalObject;
 @Data
 public class PieItemStyle implements PieItemStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/pie/PieLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.pie;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class PieLabel implements PieLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/pie/PieLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.pie;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class PieLabel implements PieLabelOption {
+public class PieLabel implements PieLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/pie/PieLabelLine.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieLabelLine.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.pie;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 @Data
 public class PieLabelLine implements PieLabelLineOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/charts/pie/PieLabelLine.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieLabelLine.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.pie;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class PieLabelLine implements PieLabelLineOption {
+public class PieLabelLine implements PieLabelLineOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/charts/pie/PieSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.pie;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -21,7 +23,10 @@ import org.icepear.echarts.origin.util.OptionEncode;
 
 @Accessors(chain = true)
 @Data
-public class PieSeries implements PieSeriesOption {
+public class PieSeries implements PieSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/pie/PieSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/pie/PieSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.pie;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -25,7 +24,6 @@ import org.icepear.echarts.origin.util.OptionEncode;
 @Data
 public class PieSeries implements PieSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/radar/RadarDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/radar/RadarDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.radar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -13,7 +16,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class RadarDataItem implements RadarDataItemOption {
+public class RadarDataItem implements RadarDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String symbol;
 

--- a/src/main/java/org/icepear/echarts/charts/radar/RadarDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/radar/RadarDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.radar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -18,7 +17,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class RadarDataItem implements RadarDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String symbol;

--- a/src/main/java/org/icepear/echarts/charts/radar/RadarEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/radar/RadarEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.radar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class RadarEmphasis implements RadarEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String focus;

--- a/src/main/java/org/icepear/echarts/charts/radar/RadarEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/radar/RadarEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.radar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class RadarEmphasis implements RadarEmphasisOption {
+public class RadarEmphasis implements RadarEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String focus;
 

--- a/src/main/java/org/icepear/echarts/charts/radar/RadarSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/radar/RadarSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.radar;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -23,7 +25,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class RadarSeries implements RadarSeriesOption {
+public class RadarSeries implements RadarSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/radar/RadarSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/radar/RadarSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.radar;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -27,7 +26,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class RadarSeries implements RadarSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeyEdgeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeyEdgeItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.sankey;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.chart.sankey.SankeyEdgeStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class SankeyEdgeItem implements SankeyEdgeItemOption {
+public class SankeyEdgeItem implements SankeyEdgeItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private SankeyEdgeStyleOption lineStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeyEdgeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeyEdgeItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sankey;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.chart.sankey.SankeyEdgeStyleOption;
 @Data
 public class SankeyEdgeItem implements SankeyEdgeItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private SankeyEdgeStyleOption lineStyle;

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeyEdgeStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeyEdgeStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sankey;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -12,7 +11,6 @@ import org.icepear.echarts.origin.chart.sankey.SankeyEdgeStyleOption;
 @Data
 public class SankeyEdgeStyle implements SankeyEdgeStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeyEdgeStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeyEdgeStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.sankey;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -7,7 +10,10 @@ import org.icepear.echarts.origin.chart.sankey.SankeyEdgeStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class SankeyEdgeStyle implements SankeyEdgeStyleOption {
+public class SankeyEdgeStyle implements SankeyEdgeStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeyEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeyEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.sankey;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class SankeyEmphasis implements SankeyEmphasisOption {
+public class SankeyEmphasis implements SankeyEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private SeriesLabelOption label;
 

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeyEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeyEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sankey;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class SankeyEmphasis implements SankeyEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private SeriesLabelOption label;

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeyLevel.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeyLevel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sankey;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class SankeyLevel implements SankeyLevelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private SeriesLabelOption label;

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeyLevel.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeyLevel.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.sankey;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class SankeyLevel implements SankeyLevelOption {
+public class SankeyLevel implements SankeyLevelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private SeriesLabelOption label;
 

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeyNodeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeyNodeItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.sankey;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class SankeyNodeItem implements SankeyNodeItemOption {
+public class SankeyNodeItem implements SankeyNodeItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private SeriesLabelOption label;
 

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeyNodeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeyNodeItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sankey;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class SankeyNodeItem implements SankeyNodeItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private SeriesLabelOption label;

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeySeries.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeySeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.sankey;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -23,7 +25,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class SankeySeries implements SankeySeriesOption {
+public class SankeySeries implements SankeySeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/sankey/SankeySeries.java
+++ b/src/main/java/org/icepear/echarts/charts/sankey/SankeySeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sankey;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -27,7 +26,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class SankeySeries implements SankeySeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/scatter/ScatterDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/scatter/ScatterDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.scatter;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class ScatterDataItem implements ScatterDataItemOption {
+public class ScatterDataItem implements ScatterDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String symbol;
 

--- a/src/main/java/org/icepear/echarts/charts/scatter/ScatterDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/scatter/ScatterDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.scatter;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class ScatterDataItem implements ScatterDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String symbol;

--- a/src/main/java/org/icepear/echarts/charts/scatter/ScatterEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/scatter/ScatterEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.scatter;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class ScatterEmphasis implements ScatterEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/scatter/ScatterEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/scatter/ScatterEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.scatter;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class ScatterEmphasis implements ScatterEmphasisOption {
+public class ScatterEmphasis implements ScatterEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/scatter/ScatterSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/scatter/ScatterSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.scatter;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -25,7 +24,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class ScatterSeries implements ScatterSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/scatter/ScatterSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/scatter/ScatterSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.scatter;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -21,7 +23,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class ScatterSeries implements ScatterSeriesOption {
+public class ScatterSeries implements ScatterSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.sunburst;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.chart.sunburst.SunburstLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class SunburstEmphasis implements SunburstEmphasisOption {
+public class SunburstEmphasis implements SunburstEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private SunburstItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sunburst;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.chart.sunburst.SunburstLabelOption;
 @Data
 public class SunburstEmphasis implements SunburstEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private SunburstItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstItemStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.sunburst;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.DecalObject;
 
 @Accessors(chain = true)
 @Data
-public class SunburstItemStyle implements SunburstItemStyleOption {
+public class SunburstItemStyle implements SunburstItemStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstItemStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sunburst;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.DecalObject;
 @Data
 public class SunburstItemStyle implements SunburstItemStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sunburst;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class SunburstLabel implements SunburstLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.sunburst;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class SunburstLabel implements SunburstLabelOption {
+public class SunburstLabel implements SunburstLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstNodeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstNodeItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.sunburst;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.chart.sunburst.SunburstNodeItemOption;
 
 @Accessors(chain = true)
 @Data
-public class SunburstNodeItem implements SunburstNodeItemOption {
+public class SunburstNodeItem implements SunburstNodeItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private SunburstItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstNodeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstNodeItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sunburst;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.chart.sunburst.SunburstNodeItemOption;
 @Data
 public class SunburstNodeItem implements SunburstNodeItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private SunburstItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.sunburst;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -21,7 +23,10 @@ import org.icepear.echarts.origin.util.LabelLineOption;
 
 @Accessors(chain = true)
 @Data
-public class SunburstSeries implements SunburstSeriesOption {
+public class SunburstSeries implements SunburstSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sunburst;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -25,7 +24,6 @@ import org.icepear.echarts.origin.util.LabelLineOption;
 @Data
 public class SunburstSeries implements SunburstSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstSeriesLevel.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstSeriesLevel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.sunburst;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.chart.sunburst.SunburstLevelOption;
 @Data
 public class SunburstSeriesLevel implements SunburstLevelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private SunburstItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/sunburst/SunburstSeriesLevel.java
+++ b/src/main/java/org/icepear/echarts/charts/sunburst/SunburstSeriesLevel.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.sunburst;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.chart.sunburst.SunburstLevelOption;
 
 @Accessors(chain = true)
 @Data
-public class SunburstSeriesLevel implements SunburstLevelOption {
+public class SunburstSeriesLevel implements SunburstLevelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private SunburstItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.themeRiver;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 @Data
 public class ThemeRiverEmphasis implements ThemeRiverEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String focus;

--- a/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.themeRiver;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class ThemeRiverEmphasis implements ThemeRiverEmphasisOption {
+public class ThemeRiverEmphasis implements ThemeRiverEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String focus;
 

--- a/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.themeRiver;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class ThemeRiverLabel implements ThemeRiverLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.themeRiver;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class ThemeRiverLabel implements ThemeRiverLabelOption {
+public class ThemeRiverLabel implements ThemeRiverLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.themeRiver;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -19,7 +21,10 @@ import org.icepear.echarts.origin.util.LabelLineOption;
 
 @Accessors(chain = true)
 @Data
-public class ThemeRiverSeries implements ThemeRiverSeriesOption {
+public class ThemeRiverSeries implements ThemeRiverSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/themeRiver/ThemeRiverSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.themeRiver;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.LabelLineOption;
 @Data
 public class ThemeRiverSeries implements ThemeRiverSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/tree/TreeEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/tree/TreeEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.tree;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class TreeEmphasis implements TreeEmphasisOption {
+public class TreeEmphasis implements TreeEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/tree/TreeEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/tree/TreeEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.tree;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class TreeEmphasis implements TreeEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/tree/TreeLeaves.java
+++ b/src/main/java/org/icepear/echarts/charts/tree/TreeLeaves.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.tree;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class TreeLeaves implements TreeLeavesOption {
+public class TreeLeaves implements TreeLeavesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/tree/TreeLeaves.java
+++ b/src/main/java/org/icepear/echarts/charts/tree/TreeLeaves.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.tree;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class TreeLeaves implements TreeLeavesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/tree/TreeNodeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/tree/TreeNodeItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.tree;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class TreeNodeItem implements TreeNodeItemOption {
+public class TreeNodeItem implements TreeNodeItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String symbol;
 

--- a/src/main/java/org/icepear/echarts/charts/tree/TreeNodeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/tree/TreeNodeItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.tree;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class TreeNodeItem implements TreeNodeItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String symbol;

--- a/src/main/java/org/icepear/echarts/charts/tree/TreeSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/tree/TreeSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.tree;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -25,7 +24,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class TreeSeries implements TreeSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/tree/TreeSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/tree/TreeSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.tree;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -21,7 +23,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class TreeSeries implements TreeSeriesOption {
+public class TreeSeries implements TreeSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/treemap/Breadcrumb.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/Breadcrumb.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.treemap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.chart.treemap.BreadcrumbOption;
 @Data
 public class Breadcrumb implements BreadcrumbOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/charts/treemap/Breadcrumb.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/Breadcrumb.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.treemap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.chart.treemap.BreadcrumbOption;
 
 @Accessors(chain = true)
 @Data
-public class Breadcrumb implements BreadcrumbOption {
+public class Breadcrumb implements BreadcrumbOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object width;

--- a/src/main/java/org/icepear/echarts/charts/treemap/BreadcrumbEmphasisItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/BreadcrumbEmphasisItemStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.treemap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -8,7 +11,10 @@ import org.icepear.echarts.origin.chart.treemap.BreadcrumbItemStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class BreadcrumbEmphasisItemStyle implements BreadcrumbEmphasisItemStyleOption {
+public class BreadcrumbEmphasisItemStyle implements BreadcrumbEmphasisItemStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private BreadcrumbItemStyleOption itemStyle;
 }

--- a/src/main/java/org/icepear/echarts/charts/treemap/BreadcrumbEmphasisItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/BreadcrumbEmphasisItemStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.treemap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -13,7 +12,6 @@ import org.icepear.echarts.origin.chart.treemap.BreadcrumbItemStyleOption;
 @Data
 public class BreadcrumbEmphasisItemStyle implements BreadcrumbEmphasisItemStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private BreadcrumbItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/treemap/BreadcrumbItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/BreadcrumbItemStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.treemap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.LabelOption;
 @Data
 public class BreadcrumbItemStyle implements BreadcrumbItemStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/treemap/BreadcrumbItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/BreadcrumbItemStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.treemap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.LabelOption;
 
 @Accessors(chain = true)
 @Data
-public class BreadcrumbItemStyle implements BreadcrumbItemStyleOption {
+public class BreadcrumbItemStyle implements BreadcrumbItemStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapEmphasis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.treemap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.chart.treemap.TreemapSeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class TreemapEmphasis implements TreemapEmphasisOption {
+public class TreemapEmphasis implements TreemapEmphasisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private TreemapSeriesItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapEmphasis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.treemap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.chart.treemap.TreemapSeriesLabelOption;
 @Data
 public class TreemapEmphasis implements TreemapEmphasisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private TreemapSeriesItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeries.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.treemap;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -26,7 +25,6 @@ import org.icepear.echarts.origin.util.LabelLineOption;
 @Data
 public class TreemapSeries implements TreemapSeriesOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeries.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.treemap;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -22,7 +24,10 @@ import org.icepear.echarts.origin.util.LabelLineOption;
 
 @Accessors(chain = true)
 @Data
-public class TreemapSeries implements TreemapSeriesOption {
+public class TreemapSeries implements TreemapSeriesOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesItemStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.treemap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.DecalObject;
 
 @Accessors(chain = true)
 @Data
-public class TreemapSeriesItemStyle implements TreemapSeriesItemStyleOption {
+public class TreemapSeriesItemStyle implements TreemapSeriesItemStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesItemStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.treemap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.DecalObject;
 @Data
 public class TreemapSeriesItemStyle implements TreemapSeriesItemStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.treemap;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class TreemapSeriesLabel implements TreemapSeriesLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesLabel.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.charts.treemap;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class TreemapSeriesLabel implements TreemapSeriesLabelOption {
+public class TreemapSeriesLabel implements TreemapSeriesLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesLevel.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesLevel.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.treemap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,7 +15,10 @@ import org.icepear.echarts.origin.util.DecalObject;
 
 @Accessors(chain = true)
 @Data
-public class TreemapSeriesLevel implements TreemapSeriesLevelOption {
+public class TreemapSeriesLevel implements TreemapSeriesLevelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object visualDimension;

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesLevel.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesLevel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.treemap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -17,7 +16,6 @@ import org.icepear.echarts.origin.util.DecalObject;
 @Data
 public class TreemapSeriesLevel implements TreemapSeriesLevelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesNodeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesNodeItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.treemap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -17,7 +16,6 @@ import org.icepear.echarts.origin.util.DecalObject;
 @Data
 public class TreemapSeriesNodeItem implements TreemapSeriesNodeItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesNodeItem.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesNodeItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.treemap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,7 +15,10 @@ import org.icepear.echarts.origin.util.DecalObject;
 
 @Accessors(chain = true)
 @Data
-public class TreemapSeriesNodeItem implements TreemapSeriesNodeItemOption {
+public class TreemapSeriesNodeItem implements TreemapSeriesNodeItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object visualDimension;

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesVisual.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesVisual.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.charts.treemap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.chart.treemap.TreemapSeriesVisualOption;
 
 @Accessors(chain = true)
 @Data
-public class TreemapSeriesVisual implements TreemapSeriesVisualOption {
+public class TreemapSeriesVisual implements TreemapSeriesVisualOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object visualDimension;

--- a/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesVisual.java
+++ b/src/main/java/org/icepear/echarts/charts/treemap/TreemapSeriesVisual.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.charts.treemap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.chart.treemap.TreemapSeriesVisualOption;
 @Data
 public class TreemapSeriesVisual implements TreemapSeriesVisualOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/axisPointer/AxisPointerLabel.java
+++ b/src/main/java/org/icepear/echarts/components/axisPointer/AxisPointerLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.axisPointer;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class AxisPointerLabel implements AxisPointerLabelOption {
+public class AxisPointerLabel implements AxisPointerLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/axisPointer/AxisPointerLabel.java
+++ b/src/main/java/org/icepear/echarts/components/axisPointer/AxisPointerLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.axisPointer;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class AxisPointerLabel implements AxisPointerLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/coord/AxisLine.java
+++ b/src/main/java/org/icepear/echarts/components/coord/AxisLine.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 @Data
 public class AxisLine implements AxisLineOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/coord/AxisLine.java
+++ b/src/main/java/org/icepear/echarts/components/coord/AxisLine.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class AxisLine implements AxisLineOption {
+public class AxisLine implements AxisLineOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object show;

--- a/src/main/java/org/icepear/echarts/components/coord/AxisNameTextStyle.java
+++ b/src/main/java/org/icepear/echarts/components/coord/AxisNameTextStyle.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.coord;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class AxisNameTextStyle implements AxisNameTextStyleOption {
+public class AxisNameTextStyle implements AxisNameTextStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/coord/AxisNameTextStyle.java
+++ b/src/main/java/org/icepear/echarts/components/coord/AxisNameTextStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class AxisNameTextStyle implements AxisNameTextStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/coord/CategoryAxisLabel.java
+++ b/src/main/java/org/icepear/echarts/components/coord/CategoryAxisLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class CategoryAxisLabel implements CategoryAxisLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/coord/CategoryAxisLabel.java
+++ b/src/main/java/org/icepear/echarts/components/coord/CategoryAxisLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.coord;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class CategoryAxisLabel implements CategoryAxisLabelOption {
+public class CategoryAxisLabel implements CategoryAxisLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/coord/CategoryAxisTick.java
+++ b/src/main/java/org/icepear/echarts/components/coord/CategoryAxisTick.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 @Data
 public class CategoryAxisTick implements CategoryAxisTickOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/coord/CategoryAxisTick.java
+++ b/src/main/java/org/icepear/echarts/components/coord/CategoryAxisTick.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class CategoryAxisTick implements CategoryAxisTickOption {
+public class CategoryAxisTick implements CategoryAxisTickOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object show;

--- a/src/main/java/org/icepear/echarts/components/coord/LogAxisLabel.java
+++ b/src/main/java/org/icepear/echarts/components/coord/LogAxisLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.coord;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class LogAxisLabel implements LogAxisLabelOption {
+public class LogAxisLabel implements LogAxisLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/coord/LogAxisLabel.java
+++ b/src/main/java/org/icepear/echarts/components/coord/LogAxisLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class LogAxisLabel implements LogAxisLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/coord/MinorSplitLine.java
+++ b/src/main/java/org/icepear/echarts/components/coord/MinorSplitLine.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -13,7 +12,6 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 @Data
 public class MinorSplitLine implements MinorSplitLineOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/components/coord/MinorSplitLine.java
+++ b/src/main/java/org/icepear/echarts/components/coord/MinorSplitLine.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -8,7 +11,10 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class MinorSplitLine implements MinorSplitLineOption {
+public class MinorSplitLine implements MinorSplitLineOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/components/coord/SplitArea.java
+++ b/src/main/java/org/icepear/echarts/components/coord/SplitArea.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.AreaStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class SplitArea implements SplitAreaOption {
+public class SplitArea implements SplitAreaOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/components/coord/SplitArea.java
+++ b/src/main/java/org/icepear/echarts/components/coord/SplitArea.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.AreaStyleOption;
 @Data
 public class SplitArea implements SplitAreaOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/components/coord/SplitLine.java
+++ b/src/main/java/org/icepear/echarts/components/coord/SplitLine.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class SplitLine implements SplitLineOption {
+public class SplitLine implements SplitLineOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/components/coord/SplitLine.java
+++ b/src/main/java/org/icepear/echarts/components/coord/SplitLine.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 @Data
 public class SplitLine implements SplitLineOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/components/coord/TimeAxisLabel.java
+++ b/src/main/java/org/icepear/echarts/components/coord/TimeAxisLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class TimeAxisLabel implements TimeAxisLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/coord/TimeAxisLabel.java
+++ b/src/main/java/org/icepear/echarts/components/coord/TimeAxisLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.coord;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class TimeAxisLabel implements TimeAxisLabelOption {
+public class TimeAxisLabel implements TimeAxisLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/coord/ValueAxisLabel.java
+++ b/src/main/java/org/icepear/echarts/components/coord/ValueAxisLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class ValueAxisLabel implements ValueAxisLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/coord/ValueAxisLabel.java
+++ b/src/main/java/org/icepear/echarts/components/coord/ValueAxisLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.coord;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class ValueAxisLabel implements ValueAxisLabelOption {
+public class ValueAxisLabel implements ValueAxisLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/coord/cartesian/CategoryAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/cartesian/CategoryAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.cartesian;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class CategoryAxis implements CategoryAxisOption {
+public class CategoryAxis implements CategoryAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number gridIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/cartesian/CategoryAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/cartesian/CategoryAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.cartesian;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class CategoryAxis implements CategoryAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number gridIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/cartesian/LogAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/cartesian/LogAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.cartesian;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class LogAxis implements LogAxisOption {
+public class LogAxis implements LogAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number gridIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/cartesian/LogAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/cartesian/LogAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.cartesian;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class LogAxis implements LogAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number gridIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/cartesian/TimeAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/cartesian/TimeAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.cartesian;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class TimeAxis implements TimeAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number gridIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/cartesian/TimeAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/cartesian/TimeAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.cartesian;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class TimeAxis implements TimeAxisOption {
+public class TimeAxis implements TimeAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number gridIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/cartesian/ValueAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/cartesian/ValueAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.cartesian;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class ValueAxis implements ValueAxisOption {
+public class ValueAxis implements ValueAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number gridIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/cartesian/ValueAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/cartesian/ValueAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.cartesian;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class ValueAxis implements ValueAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number gridIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/parallel/CategoryParallelAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/parallel/CategoryParallelAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.parallel;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class CategoryParallelAxis implements CategoryParallelAxisOption {
+public class CategoryParallelAxis implements CategoryParallelAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object dim;

--- a/src/main/java/org/icepear/echarts/components/coord/parallel/CategoryParallelAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/parallel/CategoryParallelAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.parallel;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class CategoryParallelAxis implements CategoryParallelAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/coord/parallel/LogParallelAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/parallel/LogParallelAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.parallel;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class LogParallelAxis implements LogParallelAxisOption {
+public class LogParallelAxis implements LogParallelAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object dim;

--- a/src/main/java/org/icepear/echarts/components/coord/parallel/LogParallelAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/parallel/LogParallelAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.parallel;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class LogParallelAxis implements LogParallelAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/coord/parallel/TimeParallelAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/parallel/TimeParallelAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.parallel;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class TimeParallelAxis implements TimeParallelAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/coord/parallel/TimeParallelAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/parallel/TimeParallelAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.parallel;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class TimeParallelAxis implements TimeParallelAxisOption {
+public class TimeParallelAxis implements TimeParallelAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object dim;

--- a/src/main/java/org/icepear/echarts/components/coord/parallel/ValueParallelAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/parallel/ValueParallelAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.parallel;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class ValueParallelAxis implements ValueParallelAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/coord/parallel/ValueParallelAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/parallel/ValueParallelAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.parallel;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class ValueParallelAxis implements ValueParallelAxisOption {
+public class ValueParallelAxis implements ValueParallelAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object dim;

--- a/src/main/java/org/icepear/echarts/components/coord/polar/CategoryAngleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/CategoryAngleAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.polar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class CategoryAngleAxis implements CategoryAngleAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number polarIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/polar/CategoryAngleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/CategoryAngleAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.polar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class CategoryAngleAxis implements CategoryAngleAxisOption {
+public class CategoryAngleAxis implements CategoryAngleAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number polarIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/polar/CategoryRadiusAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/CategoryRadiusAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.polar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class CategoryRadiusAxis implements CategoryRadiusAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number polarIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/polar/CategoryRadiusAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/CategoryRadiusAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.polar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class CategoryRadiusAxis implements CategoryRadiusAxisOption {
+public class CategoryRadiusAxis implements CategoryRadiusAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number polarIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/polar/LogAngleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/LogAngleAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.polar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class LogAngleAxis implements LogAngleAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number polarIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/polar/LogAngleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/LogAngleAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.polar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class LogAngleAxis implements LogAngleAxisOption {
+public class LogAngleAxis implements LogAngleAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number polarIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/polar/LogRadiusAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/LogRadiusAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.polar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class LogRadiusAxis implements LogRadiusAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number polarIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/polar/LogRadiusAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/LogRadiusAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.polar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class LogRadiusAxis implements LogRadiusAxisOption {
+public class LogRadiusAxis implements LogRadiusAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number polarIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/polar/PolarAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/PolarAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.polar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.coord.polar.PolarOption;
 @Data
 public class PolarAxis implements PolarOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/coord/polar/PolarAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/PolarAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.polar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.coord.polar.PolarOption;
 
 @Accessors(chain = true)
 @Data
-public class PolarAxis implements PolarOption {
+public class PolarAxis implements PolarOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/coord/polar/TimeAngleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/TimeAngleAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.polar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class TimeAngleAxis implements TimeAngleAxisOption {
+public class TimeAngleAxis implements TimeAngleAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number polarIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/polar/TimeAngleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/TimeAngleAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.polar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class TimeAngleAxis implements TimeAngleAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number polarIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/polar/TimeRadiusAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/TimeRadiusAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.polar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class TimeRadiusAxis implements TimeRadiusAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number polarIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/polar/TimeRadiusAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/TimeRadiusAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.polar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class TimeRadiusAxis implements TimeRadiusAxisOption {
+public class TimeRadiusAxis implements TimeRadiusAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number polarIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/polar/ValueAngleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/ValueAngleAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.polar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class ValueAngleAxis implements ValueAngleAxisOption {
+public class ValueAngleAxis implements ValueAngleAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number polarIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/polar/ValueAngleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/ValueAngleAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.polar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class ValueAngleAxis implements ValueAngleAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number polarIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/polar/ValueRadiusAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/ValueRadiusAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.polar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class ValueRadiusAxis implements ValueRadiusAxisOption {
+public class ValueRadiusAxis implements ValueRadiusAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number polarIndex;
 

--- a/src/main/java/org/icepear/echarts/components/coord/polar/ValueRadiusAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/polar/ValueRadiusAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.polar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class ValueRadiusAxis implements ValueRadiusAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number polarIndex;

--- a/src/main/java/org/icepear/echarts/components/coord/radar/RadarAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/radar/RadarAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.radar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -16,7 +19,10 @@ import org.icepear.echarts.origin.coord.radar.RadarOption;
 
 @Accessors(chain = true)
 @Data
-public class RadarAxis implements RadarOption {
+public class RadarAxis implements RadarOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/coord/radar/RadarAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/radar/RadarAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.radar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -21,7 +20,6 @@ import org.icepear.echarts.origin.coord.radar.RadarOption;
 @Data
 public class RadarAxis implements RadarOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/coord/radar/RadarAxisName.java
+++ b/src/main/java/org/icepear/echarts/components/coord/radar/RadarAxisName.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.coord.radar;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class RadarAxisName implements RadarAxisNameOption {
+public class RadarAxisName implements RadarAxisNameOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/coord/radar/RadarAxisName.java
+++ b/src/main/java/org/icepear/echarts/components/coord/radar/RadarAxisName.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.radar;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class RadarAxisName implements RadarAxisNameOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/coord/radar/RadarIndicator.java
+++ b/src/main/java/org/icepear/echarts/components/coord/radar/RadarIndicator.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.radar;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -7,7 +10,10 @@ import org.icepear.echarts.origin.coord.radar.RadarIndicatorOption;
 
 @Accessors(chain = true)
 @Data
-public class RadarIndicator implements RadarIndicatorOption {
+public class RadarIndicator implements RadarIndicatorOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String name;
 

--- a/src/main/java/org/icepear/echarts/components/coord/radar/RadarIndicator.java
+++ b/src/main/java/org/icepear/echarts/components/coord/radar/RadarIndicator.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.radar;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -12,7 +11,6 @@ import org.icepear.echarts.origin.coord.radar.RadarIndicatorOption;
 @Data
 public class RadarIndicator implements RadarIndicatorOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String name;

--- a/src/main/java/org/icepear/echarts/components/coord/single/CategorySingleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/single/CategorySingleAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.single;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class CategorySingleAxis implements CategorySingleAxisOption {
+public class CategorySingleAxis implements CategorySingleAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object width;

--- a/src/main/java/org/icepear/echarts/components/coord/single/CategorySingleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/single/CategorySingleAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.single;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class CategorySingleAxis implements CategorySingleAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/coord/single/LogSingleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/single/LogSingleAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.single;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class LogSingleAxis implements LogSingleAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/coord/single/LogSingleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/single/LogSingleAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.single;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class LogSingleAxis implements LogSingleAxisOption {
+public class LogSingleAxis implements LogSingleAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object width;

--- a/src/main/java/org/icepear/echarts/components/coord/single/TimeSingleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/single/TimeSingleAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.single;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class TimeSingleAxis implements TimeSingleAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/coord/single/TimeSingleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/single/TimeSingleAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.single;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class TimeSingleAxis implements TimeSingleAxisOption {
+public class TimeSingleAxis implements TimeSingleAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object width;

--- a/src/main/java/org/icepear/echarts/components/coord/single/ValueSingleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/single/ValueSingleAxis.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.coord.single;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -23,7 +22,6 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 @Data
 public class ValueSingleAxis implements ValueSingleAxisOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/coord/single/ValueSingleAxis.java
+++ b/src/main/java/org/icepear/echarts/components/coord/single/ValueSingleAxis.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.coord.single;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -18,7 +21,10 @@ import org.icepear.echarts.origin.util.CommonAxisPointerOption;
 
 @Accessors(chain = true)
 @Data
-public class ValueSingleAxis implements ValueSingleAxisOption {
+public class ValueSingleAxis implements ValueSingleAxisOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object width;

--- a/src/main/java/org/icepear/echarts/components/dataZoom/DataZoom.java
+++ b/src/main/java/org/icepear/echarts/components/dataZoom/DataZoom.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.dataZoom;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.LabelOption;
 
 @Accessors(chain = true)
 @Data
-public class DataZoom implements DataZoomOption {
+public class DataZoom implements DataZoomOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/dataZoom/DataZoom.java
+++ b/src/main/java/org/icepear/echarts/components/dataZoom/DataZoom.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.dataZoom;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.LabelOption;
 @Data
 public class DataZoom implements DataZoomOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/dataset/DataTransform.java
+++ b/src/main/java/org/icepear/echarts/components/dataset/DataTransform.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.dataset;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -13,7 +12,6 @@ import org.icepear.echarts.origin.data.helper.DataTransformOption;
 @Data
 public class DataTransform implements DataTransformOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String type;

--- a/src/main/java/org/icepear/echarts/components/dataset/DataTransform.java
+++ b/src/main/java/org/icepear/echarts/components/dataset/DataTransform.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.dataset;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -8,7 +11,10 @@ import org.icepear.echarts.origin.data.helper.DataTransformOption;
 
 @Accessors(chain = true)
 @Data
-public class DataTransform implements DataTransformOption {
+public class DataTransform implements DataTransformOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String type;
 

--- a/src/main/java/org/icepear/echarts/components/dataset/DataTransformConfig.java
+++ b/src/main/java/org/icepear/echarts/components/dataset/DataTransformConfig.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.dataset;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.data.helper.DataTransformConfigOption;
 
 @Accessors(chain = true)
 @Data
-public class DataTransformConfig implements DataTransformConfigOption {
+public class DataTransformConfig implements DataTransformConfigOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String dimension;
 

--- a/src/main/java/org/icepear/echarts/components/dataset/DataTransformConfig.java
+++ b/src/main/java/org/icepear/echarts/components/dataset/DataTransformConfig.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.dataset;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -14,14 +13,13 @@ import org.icepear.echarts.origin.data.helper.DataTransformConfigOption;
 @Data
 public class DataTransformConfig implements DataTransformConfigOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String dimension;
 
     @Setter(AccessLevel.NONE)
     private Object value;
-    
+
     private String order;
 
     public DataTransformConfig setValue(Number value) {

--- a/src/main/java/org/icepear/echarts/components/dataset/Dataset.java
+++ b/src/main/java/org/icepear/echarts/components/dataset/Dataset.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.dataset;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -14,7 +16,10 @@ import org.icepear.echarts.origin.util.OptionEncode;
 
 @Accessors(chain = true)
 @Data
-public class Dataset implements DatasetOption {
+public class Dataset implements DatasetOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/dataset/Dataset.java
+++ b/src/main/java/org/icepear/echarts/components/dataset/Dataset.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.dataset;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -18,7 +17,6 @@ import org.icepear.echarts.origin.util.OptionEncode;
 @Data
 public class Dataset implements DatasetOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/grid/Grid.java
+++ b/src/main/java/org/icepear/echarts/components/grid/Grid.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.grid;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.coord.cartesian.GridOption;
 
 @Accessors(chain = true)
 @Data
-public class Grid implements GridOption {
+public class Grid implements GridOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/grid/Grid.java
+++ b/src/main/java/org/icepear/echarts/components/grid/Grid.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.grid;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.coord.cartesian.GridOption;
 @Data
 public class Grid implements GridOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/legend/Legend.java
+++ b/src/main/java/org/icepear/echarts/components/legend/Legend.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.legend;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.LabelOption;
 
 @Accessors(chain = true)
 @Data
-public class Legend implements LegendOption {
+public class Legend implements LegendOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/legend/Legend.java
+++ b/src/main/java/org/icepear/echarts/components/legend/Legend.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.legend;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.LabelOption;
 @Data
 public class Legend implements LegendOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/marker/MarkArea.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkArea.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.marker;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,7 +15,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class MarkArea implements MarkAreaOption {
+public class MarkArea implements MarkAreaOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/marker/MarkArea.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkArea.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.marker;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -17,7 +16,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class MarkArea implements MarkAreaOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/marker/MarkArea1DDataItem.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkArea1DDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.marker;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class MarkArea1DDataItem implements MarkArea1DDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/components/marker/MarkArea1DDataItem.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkArea1DDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.marker;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class MarkArea1DDataItem implements MarkArea1DDataItemOption {
+public class MarkArea1DDataItem implements MarkArea1DDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/components/marker/MarkArea2DDataItem.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkArea2DDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.marker;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -8,7 +11,10 @@ import org.icepear.echarts.origin.component.marker.MarkArea2DDataItemOption;
 
 @Accessors(chain = true)
 @Data
-public class MarkArea2DDataItem implements MarkArea2DDataItemOption {
+public class MarkArea2DDataItem implements MarkArea2DDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private MarkArea2DDataItemDimOption startPoint;
 

--- a/src/main/java/org/icepear/echarts/components/marker/MarkArea2DDataItem.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkArea2DDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.marker;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -13,7 +12,6 @@ import org.icepear.echarts.origin.component.marker.MarkArea2DDataItemOption;
 @Data
 public class MarkArea2DDataItem implements MarkArea2DDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private MarkArea2DDataItemDimOption startPoint;

--- a/src/main/java/org/icepear/echarts/components/marker/MarkArea2DDataItemDim.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkArea2DDataItemDim.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.marker;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class MarkArea2DDataItemDim implements MarkArea2DDataItemDimOption {
+public class MarkArea2DDataItemDim implements MarkArea2DDataItemDimOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/components/marker/MarkArea2DDataItemDim.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkArea2DDataItemDim.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.marker;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class MarkArea2DDataItemDim implements MarkArea2DDataItemDimOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/components/marker/MarkLine.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkLine.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.marker;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -18,7 +17,6 @@ import org.icepear.echarts.origin.util.SeriesLineLabelOption;
 @Data
 public class MarkLine implements MarkLineOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/marker/MarkLine.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkLine.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.marker;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -13,7 +16,10 @@ import org.icepear.echarts.origin.util.SeriesLineLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class MarkLine implements MarkLineOption {
+public class MarkLine implements MarkLineOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/marker/MarkLine1DDataItem.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkLine1DDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.marker;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -17,7 +16,6 @@ import org.icepear.echarts.origin.util.SeriesLineLabelOption;
 @Data
 public class MarkLine1DDataItem implements MarkLine1DDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private LineStyleOption lineStyle;

--- a/src/main/java/org/icepear/echarts/components/marker/MarkLine1DDataItem.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkLine1DDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.marker;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,7 +15,10 @@ import org.icepear.echarts.origin.util.SeriesLineLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class MarkLine1DDataItem implements MarkLine1DDataItemOption {
+public class MarkLine1DDataItem implements MarkLine1DDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private LineStyleOption lineStyle;
 

--- a/src/main/java/org/icepear/echarts/components/marker/MarkLine2DDataItem.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkLine2DDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.marker;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -13,7 +12,6 @@ import org.icepear.echarts.origin.component.marker.MarkLine2DDataItemOption;
 @Data
 public class MarkLine2DDataItem implements MarkLine2DDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private MarkLine2DDataItemDimOption startPoint;

--- a/src/main/java/org/icepear/echarts/components/marker/MarkLine2DDataItem.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkLine2DDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.marker;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -8,7 +11,10 @@ import org.icepear.echarts.origin.component.marker.MarkLine2DDataItemOption;
 
 @Accessors(chain = true)
 @Data
-public class MarkLine2DDataItem implements MarkLine2DDataItemOption {
+public class MarkLine2DDataItem implements MarkLine2DDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private MarkLine2DDataItemDimOption startPoint;
 

--- a/src/main/java/org/icepear/echarts/components/marker/MarkLine2DDataItemDim.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkLine2DDataItemDim.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.marker;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -17,7 +16,6 @@ import org.icepear.echarts.origin.util.SeriesLineLabelOption;
 @Data
 public class MarkLine2DDataItemDim implements MarkLine2DDataItemDimOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private LineStyleOption lineStyle;

--- a/src/main/java/org/icepear/echarts/components/marker/MarkLine2DDataItemDim.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkLine2DDataItemDim.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.marker;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,7 +15,10 @@ import org.icepear.echarts.origin.util.SeriesLineLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class MarkLine2DDataItemDim implements MarkLine2DDataItemDimOption {
+public class MarkLine2DDataItemDim implements MarkLine2DDataItemDimOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private LineStyleOption lineStyle;
 

--- a/src/main/java/org/icepear/echarts/components/marker/MarkPoint.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkPoint.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.marker;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -17,7 +16,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class MarkPoint implements MarkPointOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/marker/MarkPoint.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkPoint.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.marker;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -12,7 +15,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class MarkPoint implements MarkPointOption {
+public class MarkPoint implements MarkPointOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/marker/MarkPointDataItem.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkPointDataItem.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.marker;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 @Data
 public class MarkPointDataItem implements MarkPointDataItemOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;

--- a/src/main/java/org/icepear/echarts/components/marker/MarkPointDataItem.java
+++ b/src/main/java/org/icepear/echarts/components/marker/MarkPointDataItem.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.marker;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.SeriesLabelOption;
 
 @Accessors(chain = true)
 @Data
-public class MarkPointDataItem implements MarkPointDataItemOption {
+public class MarkPointDataItem implements MarkPointDataItemOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private ItemStyleOption itemStyle;
 

--- a/src/main/java/org/icepear/echarts/components/media/MediaQuery.java
+++ b/src/main/java/org/icepear/echarts/components/media/MediaQuery.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.media;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -7,7 +10,10 @@ import org.icepear.echarts.origin.util.MediaQueryOption;
 
 @Accessors(chain = true)
 @Data
-public class MediaQuery implements MediaQueryOption {
+public class MediaQuery implements MediaQueryOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number minWidth;
 

--- a/src/main/java/org/icepear/echarts/components/media/MediaQuery.java
+++ b/src/main/java/org/icepear/echarts/components/media/MediaQuery.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.media;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -12,7 +11,6 @@ import org.icepear.echarts.origin.util.MediaQueryOption;
 @Data
 public class MediaQuery implements MediaQueryOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number minWidth;

--- a/src/main/java/org/icepear/echarts/components/media/MediaUnit.java
+++ b/src/main/java/org/icepear/echarts/components/media/MediaUnit.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.media;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.MediaUnitOption;
 @Data
 public class MediaUnit implements MediaUnitOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private MediaQueryOption query;

--- a/src/main/java/org/icepear/echarts/components/media/MediaUnit.java
+++ b/src/main/java/org/icepear/echarts/components/media/MediaUnit.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.media;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.MediaUnitOption;
 
 @Accessors(chain = true)
 @Data
-public class MediaUnit implements MediaUnitOption {
+public class MediaUnit implements MediaUnitOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private MediaQueryOption query;
 

--- a/src/main/java/org/icepear/echarts/components/series/AreaStyle.java
+++ b/src/main/java/org/icepear/echarts/components/series/AreaStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.series;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -12,7 +11,6 @@ import org.icepear.echarts.origin.util.AreaStyleOption;
 @Data
 public class AreaStyle implements AreaStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/series/AreaStyle.java
+++ b/src/main/java/org/icepear/echarts/components/series/AreaStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.series;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -7,7 +10,10 @@ import org.icepear.echarts.origin.util.AreaStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class AreaStyle implements AreaStyleOption {
+public class AreaStyle implements AreaStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/series/Encode.java
+++ b/src/main/java/org/icepear/echarts/components/series/Encode.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.series;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.OptionEncode;
 @Data
 public class Encode implements OptionEncode, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)

--- a/src/main/java/org/icepear/echarts/components/series/Encode.java
+++ b/src/main/java/org/icepear/echarts/components/series/Encode.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.series;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.OptionEncode;
 
 @Accessors(chain = true)
 @Data
-public class Encode implements OptionEncode {
+public class Encode implements OptionEncode, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Setter(AccessLevel.NONE)
     private Object tooltip;

--- a/src/main/java/org/icepear/echarts/components/series/ItemStyle.java
+++ b/src/main/java/org/icepear/echarts/components/series/ItemStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.series;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 @Data
 public class ItemStyle implements ItemStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/series/ItemStyle.java
+++ b/src/main/java/org/icepear/echarts/components/series/ItemStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.series;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class ItemStyle implements ItemStyleOption {
+public class ItemStyle implements ItemStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/series/LineStyle.java
+++ b/src/main/java/org/icepear/echarts/components/series/LineStyle.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.series;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -7,7 +10,10 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class LineStyle implements LineStyleOption {
+public class LineStyle implements LineStyleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/series/LineStyle.java
+++ b/src/main/java/org/icepear/echarts/components/series/LineStyle.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.series;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -12,7 +11,6 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 @Data
 public class LineStyle implements LineStyleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/series/SeriesLabel.java
+++ b/src/main/java/org/icepear/echarts/components/series/SeriesLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.series;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class SeriesLabel implements SeriesLabelOption {
+public class SeriesLabel implements SeriesLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/series/SeriesLabel.java
+++ b/src/main/java/org/icepear/echarts/components/series/SeriesLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.series;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class SeriesLabel implements SeriesLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/series/SeriesLineLabel.java
+++ b/src/main/java/org/icepear/echarts/components/series/SeriesLineLabel.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.series;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class SeriesLineLabel implements SeriesLineLabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/series/SeriesLineLabel.java
+++ b/src/main/java/org/icepear/echarts/components/series/SeriesLineLabel.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.series;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class SeriesLineLabel implements SeriesLineLabelOption {
+public class SeriesLineLabel implements SeriesLineLabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/text/Label.java
+++ b/src/main/java/org/icepear/echarts/components/text/Label.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.text;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class Label implements LabelOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/text/Label.java
+++ b/src/main/java/org/icepear/echarts/components/text/Label.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.text;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class Label implements LabelOption {
+public class Label implements LabelOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/text/LabelLayout.java
+++ b/src/main/java/org/icepear/echarts/components/text/LabelLayout.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.text;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.LabelLayoutOption;
 @Data
 public class LabelLayout implements LabelLayoutOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String moveOverlap;

--- a/src/main/java/org/icepear/echarts/components/text/LabelLayout.java
+++ b/src/main/java/org/icepear/echarts/components/text/LabelLayout.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.text;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.LabelLayoutOption;
 
 @Accessors(chain = true)
 @Data
-public class LabelLayout implements LabelLayoutOption {
+public class LabelLayout implements LabelLayoutOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String moveOverlap;
 

--- a/src/main/java/org/icepear/echarts/components/text/Text.java
+++ b/src/main/java/org/icepear/echarts/components/text/Text.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.text;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -14,7 +13,6 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 @Data
 public class Text implements TextCommonOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;

--- a/src/main/java/org/icepear/echarts/components/text/Text.java
+++ b/src/main/java/org/icepear/echarts/components/text/Text.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.text;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -9,7 +12,10 @@ import org.icepear.echarts.origin.util.TextCommonOption;
 
 @Accessors(chain = true)
 @Data
-public class Text implements TextCommonOption {
+public class Text implements TextCommonOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Number shadowBlur;
 

--- a/src/main/java/org/icepear/echarts/components/title/Title.java
+++ b/src/main/java/org/icepear/echarts/components/title/Title.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.title;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.util.LabelOption;
 
 @Accessors(chain = true)
 @Data
-public class Title implements TitleOption {
+public class Title implements TitleOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/title/Title.java
+++ b/src/main/java/org/icepear/echarts/components/title/Title.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.title;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.util.LabelOption;
 @Data
 public class Title implements TitleOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/toolbox/Toolbox.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/Toolbox.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.toolbox;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -15,7 +17,10 @@ import org.icepear.echarts.origin.util.LabelOption;
 
 @Accessors(chain = true)
 @Data
-public class Toolbox implements ToolboxOption {
+public class Toolbox implements ToolboxOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/toolbox/Toolbox.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/Toolbox.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.toolbox;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -19,7 +18,6 @@ import org.icepear.echarts.origin.util.LabelOption;
 @Data
 public class Toolbox implements ToolboxOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxBrushFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxBrushFeature.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.toolbox;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.component.toolbox.feature.ToolboxBrushFeatureO
 @Data
 public class ToolboxBrushFeature implements ToolboxBrushFeatureOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxBrushFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxBrushFeature.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.toolbox;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -11,7 +13,10 @@ import org.icepear.echarts.origin.component.toolbox.feature.ToolboxBrushFeatureO
 
 @Accessors(chain = true)
 @Data
-public class ToolboxBrushFeature implements ToolboxBrushFeatureOption {
+public class ToolboxBrushFeature implements ToolboxBrushFeatureOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDataViewFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDataViewFeature.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.toolbox;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -11,7 +13,10 @@ import org.icepear.echarts.origin.component.toolbox.feature.ToolboxDataViewFeatu
 
 @Accessors(chain = true)
 @Data
-public class ToolboxDataViewFeature implements ToolboxDataViewFeatureOption {
+public class ToolboxDataViewFeature implements ToolboxDataViewFeatureOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDataViewFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDataViewFeature.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.toolbox;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.component.toolbox.feature.ToolboxDataViewFeatu
 @Data
 public class ToolboxDataViewFeature implements ToolboxDataViewFeatureOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDataZoomFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDataZoomFeature.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.toolbox;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -12,7 +14,10 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class ToolboxDataZoomFeature implements ToolboxDataZoomFeatureOption {
+public class ToolboxDataZoomFeature implements ToolboxDataZoomFeatureOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDataZoomFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDataZoomFeature.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.toolbox;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.ItemStyleOption;
 @Data
 public class ToolboxDataZoomFeature implements ToolboxDataZoomFeatureOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDefaultFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDefaultFeature.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.toolbox;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -11,7 +13,10 @@ import org.icepear.echarts.origin.component.toolbox.ToolboxFeatureOption;
 
 @Accessors(chain = true)
 @Data
-public class ToolboxDefaultFeature implements ToolboxFeatureOption {
+public class ToolboxDefaultFeature implements ToolboxFeatureOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDefaultFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxDefaultFeature.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.toolbox;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.component.toolbox.ToolboxFeatureOption;
 @Data
 public class ToolboxDefaultFeature implements ToolboxFeatureOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxMagicTypeFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxMagicTypeFeature.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.toolbox;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -11,7 +13,10 @@ import org.icepear.echarts.origin.component.toolbox.feature.ToolboxMagicTypeFeat
 
 @Accessors(chain = true)
 @Data
-public class ToolboxMagicTypeFeature implements ToolboxMagicTypeFeatureOption {
+public class ToolboxMagicTypeFeature implements ToolboxMagicTypeFeatureOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxMagicTypeFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxMagicTypeFeature.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.toolbox;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.component.toolbox.feature.ToolboxMagicTypeFeat
 @Data
 public class ToolboxMagicTypeFeature implements ToolboxMagicTypeFeatureOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxRestoreFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxRestoreFeature.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.toolbox;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -11,7 +13,10 @@ import org.icepear.echarts.origin.component.toolbox.feature.ToolboxRestoreFeatur
 
 @Accessors(chain = true)
 @Data
-public class ToolboxRestoreFeature implements ToolboxRestoreFeatureOption {
+public class ToolboxRestoreFeature implements ToolboxRestoreFeatureOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxRestoreFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxRestoreFeature.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.toolbox;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.component.toolbox.feature.ToolboxRestoreFeatur
 @Data
 public class ToolboxRestoreFeature implements ToolboxRestoreFeatureOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxSaveAsImageFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxSaveAsImageFeature.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.toolbox;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.component.toolbox.feature.ToolboxSaveAsImageFe
 @Data
 public class ToolboxSaveAsImageFeature implements ToolboxSaveAsImageFeatureOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/components/toolbox/ToolboxSaveAsImageFeature.java
+++ b/src/main/java/org/icepear/echarts/components/toolbox/ToolboxSaveAsImageFeature.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.toolbox;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -11,7 +13,10 @@ import org.icepear.echarts.origin.component.toolbox.feature.ToolboxSaveAsImageFe
 
 @Accessors(chain = true)
 @Data
-public class ToolboxSaveAsImageFeature implements ToolboxSaveAsImageFeatureOption {
+public class ToolboxSaveAsImageFeature implements ToolboxSaveAsImageFeatureOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/components/tooltip/Tooltip.java
+++ b/src/main/java/org/icepear/echarts/components/tooltip/Tooltip.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.tooltip;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -10,7 +13,10 @@ import org.icepear.echarts.origin.component.tooltip.TooltipOption;
 
 @Accessors(chain = true)
 @Data
-public class Tooltip implements TooltipOption {
+public class Tooltip implements TooltipOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Boolean show;
 

--- a/src/main/java/org/icepear/echarts/components/tooltip/Tooltip.java
+++ b/src/main/java/org/icepear/echarts/components/tooltip/Tooltip.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.tooltip;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -15,7 +14,6 @@ import org.icepear.echarts.origin.component.tooltip.TooltipOption;
 @Data
 public class Tooltip implements TooltipOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private Boolean show;

--- a/src/main/java/org/icepear/echarts/components/tooltip/TooltipAxisPointer.java
+++ b/src/main/java/org/icepear/echarts/components/tooltip/TooltipAxisPointer.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.tooltip;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 @Data
 public class TooltipAxisPointer implements TooltipAxisPointerOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/tooltip/TooltipAxisPointer.java
+++ b/src/main/java/org/icepear/echarts/components/tooltip/TooltipAxisPointer.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.tooltip;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.LineStyleOption;
 
 @Accessors(chain = true)
 @Data
-public class TooltipAxisPointer implements TooltipAxisPointerOption {
+public class TooltipAxisPointer implements TooltipAxisPointerOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/visualMap/ContinousVisualMap.java
+++ b/src/main/java/org/icepear/echarts/components/visualMap/ContinousVisualMap.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.visualMap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.AccessLevel;
@@ -16,7 +15,6 @@ import org.icepear.echarts.origin.util.LabelOption;
 @Data
 public class ContinousVisualMap implements ContinousVisualMapOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/visualMap/ContinousVisualMap.java
+++ b/src/main/java/org/icepear/echarts/components/visualMap/ContinousVisualMap.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.visualMap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -11,7 +14,10 @@ import org.icepear.echarts.origin.util.LabelOption;
 
 @Accessors(chain = true)
 @Data
-public class ContinousVisualMap implements ContinousVisualMapOption {
+public class ContinousVisualMap implements ContinousVisualMapOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/visualMap/PiecewiseVisualMap.java
+++ b/src/main/java/org/icepear/echarts/components/visualMap/PiecewiseVisualMap.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.visualMap;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -17,7 +16,6 @@ import org.icepear.echarts.origin.util.LabelOption;
 @Data
 public class PiecewiseVisualMap implements PiecewiseVisualMapOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String mainType;

--- a/src/main/java/org/icepear/echarts/components/visualMap/PiecewiseVisualMap.java
+++ b/src/main/java/org/icepear/echarts/components/visualMap/PiecewiseVisualMap.java
@@ -1,5 +1,7 @@
 package org.icepear.echarts.components.visualMap;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -13,7 +15,10 @@ import org.icepear.echarts.origin.util.LabelOption;
 
 @Accessors(chain = true)
 @Data
-public class PiecewiseVisualMap implements PiecewiseVisualMapOption {
+public class PiecewiseVisualMap implements PiecewiseVisualMapOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mainType;
 

--- a/src/main/java/org/icepear/echarts/components/visualMap/VisualPiece.java
+++ b/src/main/java/org/icepear/echarts/components/visualMap/VisualPiece.java
@@ -1,6 +1,5 @@
 package org.icepear.echarts.components.visualMap;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import lombok.Data;
@@ -13,7 +12,6 @@ import org.icepear.echarts.origin.util.DecalObject;
 @Data
 public class VisualPiece implements VisualPieceOption, Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private String symbol;

--- a/src/main/java/org/icepear/echarts/components/visualMap/VisualPiece.java
+++ b/src/main/java/org/icepear/echarts/components/visualMap/VisualPiece.java
@@ -1,5 +1,8 @@
 package org.icepear.echarts.components.visualMap;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -8,7 +11,10 @@ import org.icepear.echarts.origin.util.DecalObject;
 
 @Accessors(chain = true)
 @Data
-public class VisualPiece implements VisualPieceOption {
+public class VisualPiece implements VisualPieceOption, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String symbol;
 

--- a/src/main/java/org/icepear/echarts/origin/data/helper/DataTransformConfigOption.java
+++ b/src/main/java/org/icepear/echarts/origin/data/helper/DataTransformConfigOption.java
@@ -12,6 +12,6 @@ public interface DataTransformConfigOption {
     DataTransformConfigOption setValue(Object value);
 
     DataTransformConfigOption setValue(String value);
-    
+
     DataTransformConfigOption setOrder(String order);
 }

--- a/src/main/java/org/icepear/echarts/render/Engine.java
+++ b/src/main/java/org/icepear/echarts/render/Engine.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class Engine {
-    private Handlebars handlebars;
+    private final Handlebars handlebars;
 
     public Engine() {
         this.handlebars = new Handlebars();
@@ -25,7 +25,7 @@ public class Engine {
 
     /**
      * Generate Html file according to the specified path
-     * 
+     *
      * @param html     a String representing in html format
      * @param path     path to save the html file
      * @param willOpen whether allowing to open the html in browser automatically
@@ -46,10 +46,11 @@ public class Engine {
 
     /**
      * Compile HandleBar template into HTML String
+     *
      * @param templateName name of the template selected
-     * @param option the option used to init the chart
-     * @param height   the height of the chart, ends with "px" or "%"
-     * @param width    the width of the chart, ends with "px" or "%"
+     * @param option       the option used to init the chart
+     * @param height       the height of the chart, ends with "px" or "%"
+     * @param width        the width of the chart, ends with "px" or "%"
      * @return HTML in String. Empty string when an exception is occurred.
      */
     private String compileHandleBars(String templateName, Option option, String height, String width) {
@@ -68,7 +69,7 @@ public class Engine {
     /**
      * Used in simple chart case, render the echarts in html file, in default width,
      * height and willOpen. The html file also provides download chart function.
-     * 
+     *
      * @param path  path to save the html file
      * @param chart the chart to be rendered
      */
@@ -79,7 +80,7 @@ public class Engine {
     /**
      * Used in advanced chart case, render the echarts in html file, in default
      * width, height and willOpen
-     * 
+     *
      * @param path   path to save the html file
      * @param option the option used to init the chart
      */
@@ -90,7 +91,7 @@ public class Engine {
     /**
      * Used in simple chart cases, render the echarts in
      * customized width, height, and willOpen
-     * 
+     *
      * @param path     path to save the html file
      * @param chart    the chart to be rendered
      * @param height   the height of the chart, ends with "px" or "%"
@@ -104,7 +105,7 @@ public class Engine {
     /**
      * Used in both simple and advanced chart cases, render the echarts in
      * customized width, height, and willOpen
-     * 
+     *
      * @param path     path to save the html file
      * @param option   the option used to init the chart
      * @param height   the height of the chart, ends with "px" or "%"
@@ -119,7 +120,7 @@ public class Engine {
     /**
      * Used in the simple case, render the echarts in default width and height,
      * without download button
-     * 
+     *
      * @param chart the chart to be rendered
      * @return a string in html format
      */
@@ -130,7 +131,7 @@ public class Engine {
     /**
      * Used in the advanced case, render the echarts in default width and height,
      * without download button
-     * 
+     *
      * @param option the option to initiate the chart
      * @return the resulted string in html format
      */
@@ -141,7 +142,7 @@ public class Engine {
     /**
      * Used in the simple cases, render the echarts in customized
      * width and height, without download button
-     * 
+     *
      * @param chart  the chart to be rendered
      * @param height the height of the chart, ends with "px" or "%"
      * @param width  the width of the chart, ends with "px" or "%"
@@ -154,7 +155,7 @@ public class Engine {
     /**
      * Used in both the simple and advanced cases, render the echarts in customized
      * width and height, without download button
-     * 
+     *
      * @param option the option to initiate the chart
      * @param height the height of the chart
      * @param width  the width of the chart
@@ -166,7 +167,7 @@ public class Engine {
 
     /**
      * Render serialized json object of Option in Chart
-     * 
+     *
      * @param chart the chart to be rendered
      * @return a string representation of a json object
      */
@@ -176,7 +177,7 @@ public class Engine {
 
     /**
      * Render serialized json object of an Option
-     * 
+     *
      * @param option the option to be serialized
      * @return a string representation of a json object
      */

--- a/src/main/java/org/icepear/echarts/serializer/EChartsSerializer.java
+++ b/src/main/java/org/icepear/echarts/serializer/EChartsSerializer.java
@@ -9,7 +9,7 @@ public class EChartsSerializer {
     private final EChartsTypeAdapter<?> markLine2DDataItemAdapter = new MarkLine2DDataItemAdapter();
     private final Gson gson;
 
-    public EChartsSerializer(EChartsTypeAdapter<?> ... typeAdapters) {
+    public EChartsSerializer(EChartsTypeAdapter<?>... typeAdapters) {
         GsonBuilder gsonBuilder = new GsonBuilder().disableHtmlEscaping()
                 .registerTypeAdapter(markArea2DDataItemAdapter.getType(), markArea2DDataItemAdapter)
                 .registerTypeAdapter(markLine2DDataItemAdapter.getType(), markLine2DDataItemAdapter);

--- a/src/main/java/org/icepear/echarts/serializer/EChartsTypeAdapter.java
+++ b/src/main/java/org/icepear/echarts/serializer/EChartsTypeAdapter.java
@@ -5,5 +5,5 @@ import java.lang.reflect.Type;
 import com.google.gson.JsonSerializer;
 
 public interface EChartsTypeAdapter<T> extends JsonSerializer<T> {
-    public Type getType();
+    Type getType();
 }


### PR DESCRIPTION
Since we use Apache Wicket, the model classes used must implement the Serializable Interface. (https://github.com/ECharts-Java/ECharts-Java/issues/91)

Changes in this PR:

- config-to-java.py: Add the Serializable interface to all classes.
- config-to-java.py: Add `@Serial` annotation (Java 14+).
- config-to-java.py: Add serialVersionUID to classes.
- Updates regenerated java classes with Serializable interface.
- Add Serializable interface to manual created classes

Because of the annotation `@Serial`, the PR https://github.com/ECharts-Java/ECharts-Java/pull/90 has to be merged first.

What do you think?