### PR TITLE
Fix build by upgrading actions/setup-java and actions/checkout

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '8'
         distribution: 'temurin'


### PR DESCRIPTION
The build is currently failing because it's still using v2 of actions/setup-java.

See [Notice of upcoming deprecations and changes in GitHub Actions services](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/?utm_source=chatgpt.com) for more information.

Therefore, I’ve updated the actions
- actions/setup-java and 
- actions/checkout 

to version v4.



