### PR TITLE
Add Map chart support (closes #100)

### DIFF
--- a/scripts/config/org/icepear/echarts/charts/map/map-data-item.json
+++ b/scripts/config/org/icepear/echarts/charts/map/map-data-item.json
@@ -1,0 +1,5 @@
+{
+  "name": "MapDataItem",
+  "type": "class",
+  "implements": ["MapDataItemOption"]
+}

--- a/scripts/config/org/icepear/echarts/charts/map/map-emphasis.json
+++ b/scripts/config/org/icepear/echarts/charts/map/map-emphasis.json
@@ -1,0 +1,5 @@
+{
+  "name": "MapEmphasis",
+  "type": "class",
+  "implements": ["MapEmphasisOption"]
+}

--- a/scripts/config/org/icepear/echarts/charts/map/map-item-style.json
+++ b/scripts/config/org/icepear/echarts/charts/map/map-item-style.json
@@ -1,0 +1,5 @@
+{
+  "name": "MapItemStyle",
+  "type": "class",
+  "implements": ["MapItemStyleOption"]
+}

--- a/scripts/config/org/icepear/echarts/charts/map/map-series.json
+++ b/scripts/config/org/icepear/echarts/charts/map/map-series.json
@@ -1,0 +1,5 @@
+{
+  "name": "MapSeries",
+  "type": "class",
+  "implements": ["MapSeriesOption"]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/map/map-data-item-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/map/map-data-item-option.json
@@ -1,0 +1,13 @@
+{
+  "name": "MapDataItemOption",
+  "type": "interface",
+  "extends": ["MapStateOption", "StatesOptionMixin"],
+  "fields": [
+    { "name": "name", "types": ["String"] },
+    { "name": "value", "types": ["Number", "Number[]"] },
+    { "name": "selected", "types": ["Boolean"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-map.data"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/map/map-emphasis-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/map/map-emphasis-option.json
@@ -1,0 +1,15 @@
+{
+  "name": "MapEmphasisOption",
+  "type": "interface",
+  "extends": [
+    "DefaultStatesMixinEmpasis",
+    "MapStateOption",
+    "EmphasisOption"
+  ],
+  "fields": [
+    { "name": "disabled", "types": ["Boolean"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-map.emphasis"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/map/map-item-style-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/map/map-item-style-option.json
@@ -1,0 +1,11 @@
+{
+  "name": "MapItemStyleOption",
+  "type": "interface",
+  "extends": ["ItemStyleOption"],
+  "fields": [
+    { "name": "areaColor", "types": ["String"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-map.itemStyle"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/map/map-series-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/map/map-series-option.json
@@ -1,0 +1,30 @@
+{
+  "name": "MapSeriesOption",
+  "type": "interface",
+  "extends": [
+    "SeriesOption",
+    "MapStateOption",
+    "BoxLayoutOptionMixin",
+    "RoamOptionMixin",
+    "SeriesEncodeOptionMixin"
+  ],
+  "fields": [
+    { "name": "type", "types": ["String"], "default": "map" },
+    { "name": "map", "types": ["String"] },
+    { "name": "aspectScale", "types": ["Number"] },
+    { "name": "boundingCoords", "types": ["Number[][]"] },
+    { "name": "layoutCenter", "types": ["String[]"] },
+    { "name": "layoutSize", "types": ["String", "Number"] },
+    { "name": "geoIndex", "types": ["Number"] },
+    { "name": "mapValueCalculation", "types": ["String"] },
+    { "name": "showLegendSymbol", "types": ["Boolean"] },
+    { "name": "projection", "types": ["Object"] },
+    { "name": "nameMap", "types": ["Object"] },
+    { "name": "nameProperty", "types": ["String"] },
+    { "name": "data", "types": ["MapDataItemOption[]"] },
+    { "name": "emphasis", "types": ["MapEmphasisOption"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-map"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/map/map-state-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/map/map-state-option.json
@@ -1,0 +1,13 @@
+{
+  "name": "MapStateOption",
+  "type": "interface",
+  "extends": [],
+  "fields": [
+    { "name": "itemStyle", "types": ["MapItemStyleOption"] },
+    { "name": "label", "types": ["SeriesLabelOption"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-map.itemStyle",
+    "https://echarts.apache.org/en/option.html#series-map.label"
+  ]
+}

--- a/src/main/java/org/icepear/echarts/MapChart.java
+++ b/src/main/java/org/icepear/echarts/MapChart.java
@@ -1,0 +1,19 @@
+package org.icepear.echarts;
+
+import java.io.Serializable;
+
+import org.icepear.echarts.charts.map.MapSeries;
+
+public class MapChart extends Chart<MapChart, MapSeries> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public MapChart() {
+        super(MapChart.class, MapSeries.class);
+    }
+
+    @Override
+    public MapSeries createSeries() {
+        return new MapSeries().setType("map");
+    }
+}

--- a/src/main/java/org/icepear/echarts/charts/map/MapDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/map/MapDataItem.java
@@ -1,0 +1,46 @@
+package org.icepear.echarts.charts.map;
+
+import java.io.Serializable;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.map.MapDataItemOption;
+import org.icepear.echarts.origin.chart.map.MapItemStyleOption;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+@Accessors(chain = true)
+@Data
+public class MapDataItem implements MapDataItemOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String name;
+
+    @Setter(AccessLevel.NONE)
+    private Object value;
+
+    public MapDataItem setValue(Number value) {
+        this.value = value;
+        return this;
+    }
+
+    public MapDataItem setValue(Number[] value) {
+        this.value = value;
+        return this;
+    }
+
+    private Boolean selected;
+
+    private MapItemStyleOption itemStyle;
+
+    private SeriesLabelOption label;
+
+    private Object emphasis;
+
+    private Object select;
+
+    private Object blur;
+}

--- a/src/main/java/org/icepear/echarts/charts/map/MapDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/map/MapDataItem.java
@@ -17,6 +17,16 @@ public class MapDataItem implements MapDataItemOption, Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    private MapItemStyleOption itemStyle;
+
+    private SeriesLabelOption label;
+
+    private Object emphasis;
+
+    private Object select;
+
+    private Object blur;
+
     private String name;
 
     @Setter(AccessLevel.NONE)
@@ -33,14 +43,4 @@ public class MapDataItem implements MapDataItemOption, Serializable {
     }
 
     private Boolean selected;
-
-    private MapItemStyleOption itemStyle;
-
-    private SeriesLabelOption label;
-
-    private Object emphasis;
-
-    private Object select;
-
-    private Object blur;
 }

--- a/src/main/java/org/icepear/echarts/charts/map/MapEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/map/MapEmphasis.java
@@ -15,8 +15,6 @@ public class MapEmphasis implements MapEmphasisOption, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private Boolean disabled;
-
     private String focus;
 
     private MapItemStyleOption itemStyle;
@@ -24,4 +22,6 @@ public class MapEmphasis implements MapEmphasisOption, Serializable {
     private SeriesLabelOption label;
 
     private Object blurScope;
+
+    private Boolean disabled;
 }

--- a/src/main/java/org/icepear/echarts/charts/map/MapEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/map/MapEmphasis.java
@@ -1,0 +1,27 @@
+package org.icepear.echarts.charts.map;
+
+import java.io.Serializable;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.map.MapEmphasisOption;
+import org.icepear.echarts.origin.chart.map.MapItemStyleOption;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+@Accessors(chain = true)
+@Data
+public class MapEmphasis implements MapEmphasisOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Boolean disabled;
+
+    private String focus;
+
+    private MapItemStyleOption itemStyle;
+
+    private SeriesLabelOption label;
+
+    private Object blurScope;
+}

--- a/src/main/java/org/icepear/echarts/charts/map/MapItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/map/MapItemStyle.java
@@ -40,8 +40,6 @@ public class MapItemStyle implements MapItemStyleOption, Serializable {
 
     private String color;
 
-    private String areaColor;
-
     private Number opacity;
 
     @Setter(AccessLevel.NONE)
@@ -56,4 +54,6 @@ public class MapItemStyle implements MapItemStyleOption, Serializable {
         this.decal = decal;
         return this;
     }
+
+    private String areaColor;
 }

--- a/src/main/java/org/icepear/echarts/charts/map/MapItemStyle.java
+++ b/src/main/java/org/icepear/echarts/charts/map/MapItemStyle.java
@@ -1,0 +1,59 @@
+package org.icepear.echarts.charts.map;
+
+import java.io.Serializable;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.map.MapItemStyleOption;
+import org.icepear.echarts.origin.util.DecalObject;
+
+@Accessors(chain = true)
+@Data
+public class MapItemStyle implements MapItemStyleOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Number shadowBlur;
+
+    private String shadowColor;
+
+    private Number shadowOffsetX;
+
+    private Number shadowOffsetY;
+
+    private String borderColor;
+
+    private Number borderWidth;
+
+    private String borderType;
+
+    private Object borderCap;
+
+    private Object borderJoin;
+
+    private Number borderDashOffset;
+
+    private Number borderMiterLimit;
+
+    private String color;
+
+    private String areaColor;
+
+    private Number opacity;
+
+    @Setter(AccessLevel.NONE)
+    private Object decal;
+
+    public MapItemStyle setDecal(DecalObject decal) {
+        this.decal = decal;
+        return this;
+    }
+
+    public MapItemStyle setDecal(String decal) {
+        this.decal = decal;
+        return this;
+    }
+}

--- a/src/main/java/org/icepear/echarts/charts/map/MapSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/map/MapSeries.java
@@ -1,0 +1,421 @@
+package org.icepear.echarts.charts.map;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.map.MapDataItemOption;
+import org.icepear.echarts.origin.chart.map.MapEmphasisOption;
+import org.icepear.echarts.origin.chart.map.MapItemStyleOption;
+import org.icepear.echarts.origin.chart.map.MapSeriesOption;
+import org.icepear.echarts.origin.component.marker.MarkAreaOption;
+import org.icepear.echarts.origin.component.marker.MarkLineOption;
+import org.icepear.echarts.origin.component.marker.MarkPointOption;
+import org.icepear.echarts.origin.util.LabelLayoutOption;
+import org.icepear.echarts.origin.util.LabelLineOption;
+import org.icepear.echarts.origin.util.OptionEncode;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+@Accessors(chain = true)
+@Data
+public class MapSeries implements MapSeriesOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String mainType;
+
+    private String type = "map";
+
+    @Setter(AccessLevel.NONE)
+    private Object id;
+
+    public MapSeries setId(Number id) {
+        this.id = id;
+        return this;
+    }
+
+    public MapSeries setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object name;
+
+    public MapSeries setName(Number name) {
+        this.name = name;
+        return this;
+    }
+
+    public MapSeries setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    private Number z;
+
+    private Number zlevel;
+
+    private Boolean animation;
+
+    private Number animationThreshold;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDuration;
+
+    public MapSeries setAnimationDuration(Number animationDuration) {
+        this.animationDuration = animationDuration;
+        return this;
+    }
+
+    public MapSeries setAnimationDuration(Object animationDuration) {
+        this.animationDuration = animationDuration;
+        return this;
+    }
+
+    private Object animationEasing;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDelay;
+
+    public MapSeries setAnimationDelay(Number animationDelay) {
+        this.animationDelay = animationDelay;
+        return this;
+    }
+
+    public MapSeries setAnimationDelay(Object animationDelay) {
+        this.animationDelay = animationDelay;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDurationUpdate;
+
+    public MapSeries setAnimationDurationUpdate(Number animationDurationUpdate) {
+        this.animationDurationUpdate = animationDurationUpdate;
+        return this;
+    }
+
+    public MapSeries setAnimationDurationUpdate(Object animationDurationUpdate) {
+        this.animationDurationUpdate = animationDurationUpdate;
+        return this;
+    }
+
+    private Object animationEasingUpdate;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDelayUpdate;
+
+    public MapSeries setAnimationDelayUpdate(Number animationDelayUpdate) {
+        this.animationDelayUpdate = animationDelayUpdate;
+        return this;
+    }
+
+    public MapSeries setAnimationDelayUpdate(Object animationDelayUpdate) {
+        this.animationDelayUpdate = animationDelayUpdate;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object color;
+
+    public MapSeries setColor(String color) {
+        this.color = color;
+        return this;
+    }
+
+    public MapSeries setColor(String[] color) {
+        this.color = color;
+        return this;
+    }
+
+    private String[][] colorLayer;
+
+    @Setter(AccessLevel.NONE)
+    private Object emphasis;
+
+    public MapSeries setEmphasis(MapEmphasisOption emphasis) {
+        this.emphasis = emphasis;
+        return this;
+    }
+
+    public MapSeries setEmphasis(Object emphasis) {
+        this.emphasis = emphasis;
+        return this;
+    }
+
+    private Object select;
+
+    private Object blur;
+
+    private MarkAreaOption markArea;
+
+    private MarkLineOption markLine;
+
+    private MarkPointOption markPoint;
+
+    private Object tooltip;
+
+    private Boolean silent;
+
+    private String blendMode;
+
+    private String cursor;
+
+    @Setter(AccessLevel.NONE)
+    private Object dataGroupId;
+
+    public MapSeries setDataGroupId(Number dataGroupId) {
+        this.dataGroupId = dataGroupId;
+        return this;
+    }
+
+    public MapSeries setDataGroupId(String dataGroupId) {
+        this.dataGroupId = dataGroupId;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object data;
+
+    public MapSeries setData(MapDataItemOption[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public MapSeries setData(Object data) {
+        this.data = data;
+        return this;
+    }
+
+    private String colorBy;
+
+    private Boolean legendHoverLink;
+
+    @Setter(AccessLevel.NONE)
+    private Object progressive;
+
+    public MapSeries setProgressive(Boolean progressive) {
+        this.progressive = progressive;
+        return this;
+    }
+
+    public MapSeries setProgressive(Number progressive) {
+        this.progressive = progressive;
+        return this;
+    }
+
+    private Number progressiveThreshold;
+
+    private String progressiveChunkMode;
+
+    private String coordinateSystem;
+
+    private Number hoverLayerThreshold;
+
+    @Setter(AccessLevel.NONE)
+    private Object seriesLayoutBy;
+
+    public MapSeries setSeriesLayoutBy(Object seriesLayoutBy) {
+        this.seriesLayoutBy = seriesLayoutBy;
+        return this;
+    }
+
+    public MapSeries setSeriesLayoutBy(String seriesLayoutBy) {
+        this.seriesLayoutBy = seriesLayoutBy;
+        return this;
+    }
+
+    private LabelLineOption labelLine;
+
+    private LabelLayoutOption labelLayout;
+
+    private Object stateAnimation;
+
+    @Setter(AccessLevel.NONE)
+    private Object universalTransition;
+
+    public MapSeries setUniversalTransition(Boolean universalTransition) {
+        this.universalTransition = universalTransition;
+        return this;
+    }
+
+    public MapSeries setUniversalTransition(Object universalTransition) {
+        this.universalTransition = universalTransition;
+        return this;
+    }
+
+    private Map<String, Boolean> selectedMap;
+
+    @Setter(AccessLevel.NONE)
+    private Object selectedMode;
+
+    public MapSeries setSelectedMode(Boolean selectedMode) {
+        this.selectedMode = selectedMode;
+        return this;
+    }
+
+    public MapSeries setSelectedMode(String selectedMode) {
+        this.selectedMode = selectedMode;
+        return this;
+    }
+
+    private MapItemStyleOption itemStyle;
+
+    private SeriesLabelOption label;
+
+    @Setter(AccessLevel.NONE)
+    private Object width;
+
+    public MapSeries setWidth(Number width) {
+        this.width = width;
+        return this;
+    }
+
+    public MapSeries setWidth(String width) {
+        this.width = width;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object height;
+
+    public MapSeries setHeight(Number height) {
+        this.height = height;
+        return this;
+    }
+
+    public MapSeries setHeight(String height) {
+        this.height = height;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object top;
+
+    public MapSeries setTop(Number top) {
+        this.top = top;
+        return this;
+    }
+
+    public MapSeries setTop(String top) {
+        this.top = top;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object right;
+
+    public MapSeries setRight(Number right) {
+        this.right = right;
+        return this;
+    }
+
+    public MapSeries setRight(String right) {
+        this.right = right;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object bottom;
+
+    public MapSeries setBottom(Number bottom) {
+        this.bottom = bottom;
+        return this;
+    }
+
+    public MapSeries setBottom(String bottom) {
+        this.bottom = bottom;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object left;
+
+    public MapSeries setLeft(Number left) {
+        this.left = left;
+        return this;
+    }
+
+    public MapSeries setLeft(String left) {
+        this.left = left;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object roam;
+
+    public MapSeries setRoam(Boolean roam) {
+        this.roam = roam;
+        return this;
+    }
+
+    public MapSeries setRoam(String roam) {
+        this.roam = roam;
+        return this;
+    }
+
+    private Number[] center;
+
+    private Number zoom;
+
+    private Object scaleLimit;
+
+    private Number datasetIndex;
+
+    @Setter(AccessLevel.NONE)
+    private Object datasetId;
+
+    public MapSeries setDatasetId(Number datasetId) {
+        this.datasetId = datasetId;
+        return this;
+    }
+
+    public MapSeries setDatasetId(String datasetId) {
+        this.datasetId = datasetId;
+        return this;
+    }
+
+    private Object sourceHeader;
+
+    private Object[] dimensions;
+
+    private OptionEncode encode;
+
+    private String map;
+
+    private Number aspectScale;
+
+    private Number[][] boundingCoords;
+
+    private String[] layoutCenter;
+
+    @Setter(AccessLevel.NONE)
+    private Object layoutSize;
+
+    public MapSeries setLayoutSize(Number layoutSize) {
+        this.layoutSize = layoutSize;
+        return this;
+    }
+
+    public MapSeries setLayoutSize(String layoutSize) {
+        this.layoutSize = layoutSize;
+        return this;
+    }
+
+    private Number geoIndex;
+
+    private String mapValueCalculation;
+
+    private Boolean showLegendSymbol;
+
+    private Object projection;
+
+    private Object nameMap;
+
+    private String nameProperty;
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/map/MapDataItemOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/map/MapDataItemOption.java
@@ -1,0 +1,17 @@
+package org.icepear.echarts.origin.chart.map;
+
+import org.icepear.echarts.origin.util.StatesOptionMixin;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-map.data
+ */
+public interface MapDataItemOption extends MapStateOption, StatesOptionMixin {
+
+    MapDataItemOption setName(String name);
+
+    MapDataItemOption setValue(Number value);
+
+    MapDataItemOption setValue(Number[] value);
+
+    MapDataItemOption setSelected(Boolean selected);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/map/MapEmphasisOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/map/MapEmphasisOption.java
@@ -1,0 +1,12 @@
+package org.icepear.echarts.origin.chart.map;
+
+import org.icepear.echarts.origin.util.DefaultStatesMixinEmpasis;
+import org.icepear.echarts.origin.util.EmphasisOption;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-map.emphasis
+ */
+public interface MapEmphasisOption extends DefaultStatesMixinEmpasis, MapStateOption, EmphasisOption {
+
+    MapEmphasisOption setDisabled(Boolean disabled);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/map/MapItemStyleOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/map/MapItemStyleOption.java
@@ -1,0 +1,11 @@
+package org.icepear.echarts.origin.chart.map;
+
+import org.icepear.echarts.origin.util.ItemStyleOption;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-map.itemStyle
+ */
+public interface MapItemStyleOption extends ItemStyleOption {
+
+    MapItemStyleOption setAreaColor(String areaColor);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/map/MapSeriesOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/map/MapSeriesOption.java
@@ -1,0 +1,43 @@
+package org.icepear.echarts.origin.chart.map;
+
+import org.icepear.echarts.origin.util.BoxLayoutOptionMixin;
+import org.icepear.echarts.origin.util.RoamOptionMixin;
+import org.icepear.echarts.origin.util.SeriesEncodeOptionMixin;
+import org.icepear.echarts.origin.util.SeriesOption;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-map
+ */
+public interface MapSeriesOption
+        extends SeriesOption, MapStateOption, BoxLayoutOptionMixin, RoamOptionMixin, SeriesEncodeOptionMixin {
+
+    MapSeriesOption setType(String type);
+
+    MapSeriesOption setMap(String map);
+
+    MapSeriesOption setAspectScale(Number aspectScale);
+
+    MapSeriesOption setBoundingCoords(Number[][] boundingCoords);
+
+    MapSeriesOption setLayoutCenter(String[] layoutCenter);
+
+    MapSeriesOption setLayoutSize(Number layoutSize);
+
+    MapSeriesOption setLayoutSize(String layoutSize);
+
+    MapSeriesOption setGeoIndex(Number geoIndex);
+
+    MapSeriesOption setMapValueCalculation(String mapValueCalculation);
+
+    MapSeriesOption setShowLegendSymbol(Boolean showLegendSymbol);
+
+    MapSeriesOption setProjection(Object projection);
+
+    MapSeriesOption setNameMap(Object nameMap);
+
+    MapSeriesOption setNameProperty(String nameProperty);
+
+    MapSeriesOption setData(MapDataItemOption[] data);
+
+    MapSeriesOption setEmphasis(MapEmphasisOption emphasis);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/map/MapStateOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/map/MapStateOption.java
@@ -1,0 +1,14 @@
+package org.icepear.echarts.origin.chart.map;
+
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-map.itemStyle
+ * https://echarts.apache.org/en/option.html#series-map.label
+ */
+public interface MapStateOption {
+
+    MapStateOption setItemStyle(MapItemStyleOption itemStyle);
+
+    MapStateOption setLabel(SeriesLabelOption label);
+}

--- a/src/test/java/org/icepear/echarts/advanced/map/UsaMapChartTest.java
+++ b/src/test/java/org/icepear/echarts/advanced/map/UsaMapChartTest.java
@@ -1,0 +1,72 @@
+package org.icepear.echarts.advanced.map;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import org.icepear.echarts.MapChart;
+import org.icepear.echarts.charts.map.MapDataItem;
+import org.icepear.echarts.charts.map.MapEmphasis;
+import org.icepear.echarts.charts.map.MapItemStyle;
+import org.icepear.echarts.charts.map.MapSeries;
+import org.icepear.echarts.components.series.SeriesLabel;
+import org.icepear.echarts.components.title.Title;
+import org.icepear.echarts.components.tooltip.Tooltip;
+import org.icepear.echarts.components.visualMap.ContinousVisualMap;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+/**
+ * Reproduces the official USA map example referenced in issue #100:
+ * https://echarts.apache.org/examples/en/editor.html?c=map-usa
+ */
+public class UsaMapChartTest {
+
+    @Test
+    public void testUsaMapChart() {
+        MapDataItem[] data = new MapDataItem[] {
+                new MapDataItem().setName("Alabama").setValue(4822023),
+                new MapDataItem().setName("Alaska").setValue(731449),
+                new MapDataItem().setName("Arizona").setValue(6553255),
+                new MapDataItem().setName("California").setValue(38041430),
+                new MapDataItem().setName("Texas").setValue(26059203),
+                new MapDataItem().setName("New York").setValue(19570261),
+                new MapDataItem().setName("Puerto Rico").setValue(3667084)
+        };
+
+        MapSeries series = new MapSeries()
+                .setName("USA PopEstimates")
+                .setMap("USA")
+                .setRoam(true)
+                .setItemStyle(new MapItemStyle().setAreaColor("rgb(135, 169, 240)").setBorderColor("#fff"))
+                .setEmphasis(new MapEmphasis()
+                        .setLabel(new SeriesLabel().setShow(true))
+                        .setItemStyle(new MapItemStyle().setAreaColor("rgb(177, 195, 245)")))
+                .setData(data);
+
+        ContinousVisualMap visualMap = new ContinousVisualMap()
+                .setLeft("right")
+                .setMin(500000)
+                .setMax(38000000)
+                .setText(new String[] { "High", "Low" })
+                .setRealtime(false)
+                .setCalculable(true)
+                .setColor(new String[] { "orangered", "yellow", "lightskyblue" });
+
+        MapChart chart = new MapChart()
+                .setTitle(new Title().setText("USA Population Estimates (2012)").setLeft("right"))
+                .setTooltip(new Tooltip().setTrigger("item").setShowDelay(0).setTransitionDuration(0.2))
+                .setVisualMap(visualMap)
+                .addSeries(series);
+
+        Reader reader = new InputStreamReader(
+                this.getClass().getResourceAsStream("/advanced/map/usa-map-chart.json"));
+        JsonElement expected = JsonParser.parseReader(reader);
+        JsonElement actual = new EChartsSerializer().toJsonTree(chart.getOption());
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/org/icepear/echarts/charts/map/MapSeriesTest.java
+++ b/src/test/java/org/icepear/echarts/charts/map/MapSeriesTest.java
@@ -1,0 +1,230 @@
+package org.icepear.echarts.charts.map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.icepear.echarts.MapChart;
+import org.icepear.echarts.Option;
+import org.icepear.echarts.components.series.SeriesLabel;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+/**
+ * Direct unit tests of the Map chart classes — exercises setters, defaults, the
+ * RoamOptionMixin/BoxLayoutOptionMixin overloads, and the data overloads to
+ * keep coverage tight without relying solely on snapshot fixtures.
+ */
+public class MapSeriesTest {
+
+    private static final EChartsSerializer SERIALIZER = new EChartsSerializer();
+
+    @Test
+    public void testDefaultTypeIsMap() {
+        assertEquals("map", new MapSeries().getType());
+    }
+
+    @Test
+    public void testMapChartFactoryProducesMapSeries() {
+        MapChart chart = new MapChart()
+                .addSeries(new MapSeries().setMap("USA"));
+        Option option = chart.getOption();
+        JsonElement json = SERIALIZER.toJsonTree(option);
+        JsonObject series = json.getAsJsonObject()
+                .get("series").getAsJsonArray()
+                .get(0).getAsJsonObject();
+        assertEquals("map", series.get("type").getAsString());
+        assertEquals("USA", series.get("map").getAsString());
+    }
+
+    @Test
+    public void testRoamAcceptsBooleanAndString() {
+        MapSeries asBool = new MapSeries().setRoam(true);
+        assertEquals(Boolean.TRUE, asBool.getRoam());
+
+        MapSeries asString = new MapSeries().setRoam("scale");
+        assertEquals("scale", asString.getRoam());
+    }
+
+    @Test
+    public void testLayoutSizeAndCenter() {
+        MapSeries series = new MapSeries()
+                .setLayoutCenter(new String[] { "50%", "50%" })
+                .setLayoutSize("100%")
+                .setCenter(new Number[] { 104.114129, 37.550339 })
+                .setZoom(1.5);
+
+        assertArrayEquals(new String[] { "50%", "50%" }, series.getLayoutCenter());
+        assertEquals("100%", series.getLayoutSize());
+        assertArrayEquals(new Number[] { 104.114129, 37.550339 }, series.getCenter());
+        assertEquals(1.5, series.getZoom().doubleValue(), 0.0);
+    }
+
+    @Test
+    public void testLayoutSizeNumericOverload() {
+        MapSeries series = new MapSeries().setLayoutSize(400);
+        assertEquals(400, ((Number) series.getLayoutSize()).intValue());
+    }
+
+    @Test
+    public void testBoxLayoutOverloadsCoexist() {
+        MapSeries series = new MapSeries()
+                .setLeft("10%").setTop(20)
+                .setRight("5%").setBottom(15)
+                .setWidth("80%").setHeight(300);
+        assertEquals("10%", series.getLeft());
+        assertEquals(20, ((Number) series.getTop()).intValue());
+        assertEquals("5%", series.getRight());
+        assertEquals(15, ((Number) series.getBottom()).intValue());
+        assertEquals("80%", series.getWidth());
+        assertEquals(300, ((Number) series.getHeight()).intValue());
+    }
+
+    @Test
+    public void testDataItemOverloads() {
+        MapDataItem scalar = new MapDataItem().setName("California").setValue(393);
+        MapDataItem vector = new MapDataItem().setName("Texas").setValue(new Number[] { 1, 2, 3 });
+
+        assertEquals(393, ((Number) scalar.getValue()).intValue());
+        assertNotNull(vector.getValue());
+        assertTrue(vector.getValue() instanceof Number[]);
+    }
+
+    @Test
+    public void testEmphasisItemStyleAndLabelSerialization() {
+        MapSeries series = new MapSeries()
+                .setMap("USA")
+                .setEmphasis(new MapEmphasis()
+                        .setFocus("self")
+                        .setLabel(new SeriesLabel().setShow(true))
+                        .setItemStyle(new MapItemStyle().setAreaColor("#abc")));
+
+        JsonElement json = SERIALIZER.toJsonTree(series);
+        JsonObject emphasis = json.getAsJsonObject().get("emphasis").getAsJsonObject();
+        assertEquals("self", emphasis.get("focus").getAsString());
+        assertEquals("#abc", emphasis.get("itemStyle").getAsJsonObject().get("areaColor").getAsString());
+        assertEquals(true, emphasis.get("label").getAsJsonObject().get("show").getAsBoolean());
+    }
+
+    @Test
+    public void testRawDataObjectOverload() {
+        Object[] rawData = new Object[] {
+                new MapDataItem().setName("A").setValue(1),
+                new MapDataItem().setName("B").setValue(2)
+        };
+        MapSeries series = new MapSeries().setData(rawData);
+        JsonElement json = SERIALIZER.toJsonTree(series);
+        assertEquals(2, json.getAsJsonObject().get("data").getAsJsonArray().size());
+    }
+
+    @Test
+    public void testItemStyleAreaColorSerializesUnderItemStyle() {
+        MapSeries series = new MapSeries()
+                .setMap("world")
+                .setItemStyle(new MapItemStyle().setAreaColor("rgb(1,2,3)").setBorderColor("#000"));
+
+        String json = SERIALIZER.toJson(series);
+        // areaColor must be nested inside itemStyle, not on the series root.
+        assertTrue(json.contains("\"itemStyle\":{"));
+        assertTrue(json.contains("\"areaColor\":\"rgb(1,2,3)\""));
+        assertTrue(json.contains("\"borderColor\":\"#000\""));
+    }
+
+    @Test
+    public void testNullableFieldsAreOmitted() {
+        // Only setting required-ish things: nothing else should leak into JSON.
+        MapSeries series = new MapSeries().setMap("USA");
+        JsonObject json = SERIALIZER.toJsonTree(series).getAsJsonObject();
+        assertEquals("map", json.get("type").getAsString());
+        assertEquals("USA", json.get("map").getAsString());
+        assertNull(json.get("roam"));
+        assertNull(json.get("center"));
+        assertNull(json.get("data"));
+        assertNull(json.get("emphasis"));
+    }
+
+    @Test
+    public void testNameMapAndNameProperty() {
+        java.util.Map<String, String> nameMap = new java.util.HashMap<>();
+        nameMap.put("United States", "USA");
+        MapSeries series = new MapSeries()
+                .setMap("world")
+                .setNameMap(nameMap)
+                .setNameProperty("name");
+
+        JsonObject json = SERIALIZER.toJsonTree(series).getAsJsonObject();
+        assertEquals("name", json.get("nameProperty").getAsString());
+        assertEquals("USA", json.get("nameMap").getAsJsonObject().get("United States").getAsString());
+    }
+
+    @Test
+    public void testProjectionAndShowLegendSymbolFlags() {
+        MapSeries series = new MapSeries()
+                .setMap("USA")
+                .setShowLegendSymbol(false)
+                .setMapValueCalculation("sum")
+                .setAspectScale(0.75);
+
+        JsonObject json = SERIALIZER.toJsonTree(series).getAsJsonObject();
+        assertEquals(false, json.get("showLegendSymbol").getAsBoolean());
+        assertEquals("sum", json.get("mapValueCalculation").getAsString());
+        assertEquals(0.75, json.get("aspectScale").getAsDouble(), 0.0);
+    }
+
+    @Test
+    public void testDataItemSelected() {
+        MapDataItem item = new MapDataItem().setName("CA").setValue(1).setSelected(true);
+        JsonObject json = SERIALIZER.toJsonTree(item).getAsJsonObject();
+        assertEquals(true, json.get("selected").getAsBoolean());
+    }
+
+    @Test
+    public void testMapChartChainable() {
+        // Verifies the wrapper chains correctly and the constructor wires the right type token.
+        MapChart chart = new MapChart()
+                .setTitle("My map")
+                .setLegend()
+                .addSeries(new MapSeries().setMap("USA"));
+        Option option = chart.getOption();
+        assertNotNull(option.getTitle());
+        assertNotNull(option.getLegend());
+        assertNotNull(option.getSeries());
+    }
+
+    @Test
+    public void testParsedJsonRoundTripsAreEqual() {
+        MapSeries series = new MapSeries().setMap("USA").setRoam(true);
+        String json = SERIALIZER.toJson(series);
+        JsonElement parsed = JsonParser.parseString(json);
+        JsonElement reSerialized = JsonParser.parseString(SERIALIZER.toJson(series));
+        assertEquals(parsed, reSerialized);
+    }
+
+    @Test
+    public void testBoundingCoords() {
+        Number[][] coords = new Number[][] { { -180, 90 }, { 180, -90 } };
+        MapSeries series = new MapSeries().setMap("world").setBoundingCoords(coords);
+        JsonObject json = SERIALIZER.toJsonTree(series).getAsJsonObject();
+        assertEquals(2, json.get("boundingCoords").getAsJsonArray().size());
+    }
+
+    @Test
+    public void testGeoIndexSerializes() {
+        MapSeries series = new MapSeries().setGeoIndex(0);
+        JsonObject json = SERIALIZER.toJsonTree(series).getAsJsonObject();
+        assertEquals(0, json.get("geoIndex").getAsInt());
+    }
+
+    @Test
+    public void testMapEmphasisDisabledFlag() {
+        MapEmphasis emphasis = new MapEmphasis().setDisabled(true);
+        JsonObject json = SERIALIZER.toJsonTree(emphasis).getAsJsonObject();
+        assertEquals(true, json.get("disabled").getAsBoolean());
+    }
+}

--- a/src/test/java/org/icepear/echarts/render/simple/RenderMapByChartTest.java
+++ b/src/test/java/org/icepear/echarts/render/simple/RenderMapByChartTest.java
@@ -1,0 +1,45 @@
+package org.icepear.echarts.render.simple;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.icepear.echarts.Chart;
+import org.icepear.echarts.MapChart;
+import org.icepear.echarts.charts.map.MapDataItem;
+import org.icepear.echarts.charts.map.MapSeries;
+import org.icepear.echarts.render.Engine;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RenderMapByChartTest {
+    private Chart<?, ?> chart;
+
+    @Before
+    public void constructChart() {
+        MapDataItem[] data = new MapDataItem[] {
+                new MapDataItem().setName("California").setValue(393),
+                new MapDataItem().setName("Texas").setValue(295)
+        };
+        this.chart = new MapChart()
+                .setTitle("USA Map")
+                .addSeries(new MapSeries().setMap("USA").setRoam(true).setData(data));
+    }
+
+    @Test
+    public void testRenderMapJsonOption() {
+        Engine engine = new Engine();
+        String json = engine.renderJsonOption(chart);
+        assertNotNull(json);
+        assertTrue("rendered json must include map series type", json.contains("\"type\":\"map\""));
+        assertTrue("rendered json must include the configured map name", json.contains("\"map\":\"USA\""));
+    }
+
+    @Test
+    public void testRenderMapHtml() {
+        Engine engine = new Engine();
+        String html = engine.renderHtml(chart);
+        assertNotNull(html);
+        assertTrue("rendered html must contain echarts setOption", html.contains("setOption"));
+        assertTrue("rendered html must embed series json", html.contains("\"map\":\"USA\""));
+    }
+}

--- a/src/test/java/org/icepear/echarts/simple/map/BasicMapTest.java
+++ b/src/test/java/org/icepear/echarts/simple/map/BasicMapTest.java
@@ -1,0 +1,35 @@
+package org.icepear.echarts.simple.map;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import org.icepear.echarts.MapChart;
+import org.icepear.echarts.charts.map.MapDataItem;
+import org.icepear.echarts.charts.map.MapSeries;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+public class BasicMapTest {
+
+    @Test
+    public void testBasicMap() {
+        MapDataItem[] data = new MapDataItem[] {
+                new MapDataItem().setName("California").setValue(393),
+                new MapDataItem().setName("Texas").setValue(295),
+                new MapDataItem().setName("New York").setValue(202)
+        };
+        MapChart chart = new MapChart()
+                .addSeries(new MapSeries().setMap("USA").setRoam(true).setData(data));
+
+        Reader reader = new InputStreamReader(
+                this.getClass().getResourceAsStream("/simple/map/basic-map.json"));
+        JsonElement expected = JsonParser.parseReader(reader);
+        JsonElement actual = new EChartsSerializer().toJsonTree(chart.getOption());
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/resources/advanced/map/usa-map-chart.json
+++ b/src/test/resources/advanced/map/usa-map-chart.json
@@ -1,0 +1,35 @@
+{
+  "title": { "left": "right", "text": "USA Population Estimates (2012)" },
+  "tooltip": { "showDelay": 0, "transitionDuration": 0.2, "trigger": "item" },
+  "visualMap": {
+    "left": "right",
+    "realtime": false,
+    "min": 500000,
+    "max": 38000000,
+    "color": ["orangered", "yellow", "lightskyblue"],
+    "text": ["High", "Low"],
+    "calculable": true
+  },
+  "series": [
+    {
+      "type": "map",
+      "name": "USA PopEstimates",
+      "emphasis": {
+        "itemStyle": { "areaColor": "rgb(177, 195, 245)" },
+        "label": { "show": true }
+      },
+      "data": [
+        { "name": "Alabama", "value": 4822023 },
+        { "name": "Alaska", "value": 731449 },
+        { "name": "Arizona", "value": 6553255 },
+        { "name": "California", "value": 38041430 },
+        { "name": "Texas", "value": 26059203 },
+        { "name": "New York", "value": 19570261 },
+        { "name": "Puerto Rico", "value": 3667084 }
+      ],
+      "itemStyle": { "borderColor": "#fff", "areaColor": "rgb(135, 169, 240)" },
+      "roam": true,
+      "map": "USA"
+    }
+  ]
+}

--- a/src/test/resources/simple/map/basic-map.json
+++ b/src/test/resources/simple/map/basic-map.json
@@ -1,0 +1,14 @@
+{
+  "series": [
+    {
+      "type": "map",
+      "data": [
+        { "name": "California", "value": 393 },
+        { "name": "Texas", "value": 295 },
+        { "name": "New York", "value": 202 }
+      ],
+      "map": "USA",
+      "roam": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a Map chart series (`type: "map"`) so users can render GEO/region maps such as the official [USA example](https://echarts.apache.org/examples/en/editor.html?c=map-usa) without writing a custom `SeriesOption`.
- Mirrors the structure of existing charts (Funnel/Treemap/Heatmap): origin interfaces under `org.icepear.echarts.origin.chart.map.*` and Lombok data classes under `org.icepear.echarts.charts.map.*`, with a `MapChart` wrapper extending `Chart<MapChart, MapSeries>`.
- Map-specific extras: `MapItemStyle.areaColor`, `setMap`, `setRoam` (Boolean/String overloads), `setLayoutCenter` / `setLayoutSize`, `setBoundingCoords`, `setNameMap`, `setNameProperty`, `setProjection`, `setShowLegendSymbol`, `setMapValueCalculation`, `setAspectScale`, `setGeoIndex`.

## Public API added
- `MapChart`
- `charts.map.MapSeries`, `MapDataItem`, `MapEmphasis`, `MapItemStyle`
- `origin.chart.map.MapSeriesOption`, `MapStateOption`, `MapEmphasisOption`, `MapDataItemOption`, `MapItemStyleOption`

## Example usage
```java
MapChart chart = new MapChart()
    .setTitle(new Title().setText("USA Population Estimates (2012)").setLeft("right"))
    .setTooltip(new Tooltip().setTrigger("item"))
    .setVisualMap(new ContinousVisualMap().setMin(500_000).setMax(38_000_000)
        .setColor(new String[]{"orangered","yellow","lightskyblue"}).setCalculable(true))
    .addSeries(new MapSeries()
        .setName("USA PopEstimates")
        .setMap("USA")
        .setRoam(true)
        .setItemStyle(new MapItemStyle().setAreaColor("rgb(135, 169, 240)").setBorderColor("#fff"))
        .setEmphasis(new MapEmphasis()
            .setLabel(new SeriesLabel().setShow(true))
            .setItemStyle(new MapItemStyle().setAreaColor("rgb(177, 195, 245)")))
        .setData(new MapDataItem[]{
            new MapDataItem().setName("California").setValue(38041430),
            new MapDataItem().setName("Texas").setValue(26059203),
            // ...
        }));

String json = new EChartsSerializer().toJson(chart.getOption());
```

## Tests added (23 new tests, all passing locally)
- `simple/map/BasicMapTest` — minimal happy-path snapshot
- `advanced/map/UsaMapChartTest` — reproduces the issue's USA example
- `charts/map/MapSeriesTest` — 19 unit tests covering setter overloads (roam Bool/String, layoutSize Number/String, BoxLayout overloads, raw `Object` data overload), null-omission semantics, `areaColor` nested under `itemStyle`, `MapEmphasis.disabled`, `nameMap`/`nameProperty`, `boundingCoords`, `geoIndex`, `MapChart` chaining
- `render/simple/RenderMapByChartTest` — exercises the Handlebars render Engine end-to-end with the Map chart

## Test plan
- [x] `mvn test -Dtest=BasicMapTest` — 1/1 pass
- [x] `mvn test -Dtest=UsaMapChartTest` — 1/1 pass
- [x] `mvn test -Dtest=MapSeriesTest` — 19/19 pass
- [x] `mvn test -Dtest=RenderMapByChartTest` — 2/2 pass
- [x] `mvn test` (full suite) — all 23 new tests pass; only the 3 pre-existing float-precision failures (`TwoValueAxesInPolar1Test`, `TwoValueAxesInPolar2Test`, `BasicPolarLineTest`) remain, present on `master` before this branch and unrelated to this change

Closes #100

https://github.com/user-attachments/assets/bd4b9e29-0912-41c7-8996-59422f8145ea

