### PR TITLE
Add EffectScatter chart support

### DIFF
--- a/scripts/config/org/icepear/echarts/charts/effectScatter/effect-scatter-data-item.json
+++ b/scripts/config/org/icepear/echarts/charts/effectScatter/effect-scatter-data-item.json
@@ -1,0 +1,5 @@
+{
+  "name": "EffectScatterDataItem",
+  "type": "class",
+  "implements": ["EffectScatterDataItemOption"]
+}

--- a/scripts/config/org/icepear/echarts/charts/effectScatter/effect-scatter-emphasis.json
+++ b/scripts/config/org/icepear/echarts/charts/effectScatter/effect-scatter-emphasis.json
@@ -1,0 +1,5 @@
+{
+  "name": "EffectScatterEmphasis",
+  "type": "class",
+  "implements": ["EffectScatterEmphasisOption"]
+}

--- a/scripts/config/org/icepear/echarts/charts/effectScatter/effect-scatter-series.json
+++ b/scripts/config/org/icepear/echarts/charts/effectScatter/effect-scatter-series.json
@@ -1,0 +1,5 @@
+{
+  "name": "EffectScatterSeries",
+  "type": "class",
+  "implements": ["EffectScatterSeriesOption"]
+}

--- a/scripts/config/org/icepear/echarts/charts/effectScatter/ripple-effect.json
+++ b/scripts/config/org/icepear/echarts/charts/effectScatter/ripple-effect.json
@@ -1,0 +1,5 @@
+{
+  "name": "RippleEffect",
+  "type": "class",
+  "implements": ["RippleEffectOption"]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/effectScatter/effect-scatter-data-item-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/effectScatter/effect-scatter-data-item-option.json
@@ -1,0 +1,14 @@
+{
+  "name": "EffectScatterDataItemOption",
+  "type": "interface",
+  "extends": [
+    "SymbolOptionMixin",
+    "EffectScatterStateOption",
+    "StatesOptionMixin",
+    "DefaultOptionDataItemObject"
+  ],
+  "fields": [],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-effectScatter.data"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/effectScatter/effect-scatter-emphasis-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/effectScatter/effect-scatter-emphasis-option.json
@@ -1,0 +1,13 @@
+{
+  "name": "EffectScatterEmphasisOption",
+  "type": "interface",
+  "extends": ["EffectScatterStateOption", "EmphasisOption"],
+  "fields": [
+    { "name": "focus", "types": ["String"] },
+    { "name": "scale", "types": ["Boolean"] },
+    { "name": "disabled", "types": ["Boolean"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-effectScatter.emphasis"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/effectScatter/effect-scatter-series-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/effectScatter/effect-scatter-series-option.json
@@ -1,0 +1,42 @@
+{
+  "name": "EffectScatterSeriesOption",
+  "type": "interface",
+  "extends": [
+    "SeriesOption",
+    "EffectScatterStateOption",
+    "SeriesOnCartesianOptionMixin",
+    "SeriesOnPolarOptionMixin",
+    "SeriesOnCalendarOptionMixin",
+    "SeriesOnGeoOptionMixin",
+    "SeriesOnSingleOptionMixin",
+    "SymbolOptionMixin",
+    "SeriesEncodeOptionMixin"
+  ],
+  "fields": [
+    { "name": "type", "types": ["String"], "default": "effectScatter" },
+    { "name": "coordinateSystem", "types": ["String"] },
+    { "name": "effectType", "types": ["String"] },
+    { "name": "showEffectOn", "types": ["String"] },
+    { "name": "rippleEffect", "types": ["RippleEffectOption"] },
+    { "name": "clip", "types": ["Boolean"] },
+    {
+      "name": "data",
+      "types": [
+        "String[]",
+        "String[][]",
+        "Number[]",
+        "Number[][]",
+        "Date[]",
+        "Date[][]",
+        "EffectScatterDataItemOption[]"
+      ]
+    },
+    {
+      "name": "emphasis",
+      "types": ["EffectScatterEmphasisOption"]
+    }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-effectScatter"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/effectScatter/effect-scatter-state-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/effectScatter/effect-scatter-state-option.json
@@ -1,0 +1,13 @@
+{
+  "name": "EffectScatterStateOption",
+  "type": "interface",
+  "extends": [],
+  "fields": [
+    { "name": "itemStyle", "types": ["ItemStyleOption"] },
+    { "name": "label", "types": ["SeriesLabelOption"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-effectScatter.itemStyle",
+    "https://echarts.apache.org/en/option.html#series-effectScatter.label"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/effectScatter/ripple-effect-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/effectScatter/ripple-effect-option.json
@@ -1,0 +1,15 @@
+{
+  "name": "RippleEffectOption",
+  "type": "interface",
+  "extends": [],
+  "fields": [
+    { "name": "color", "types": ["String"] },
+    { "name": "number", "types": ["Number"] },
+    { "name": "period", "types": ["Number"] },
+    { "name": "scale", "types": ["Number"] },
+    { "name": "brushType", "types": ["String"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-effectScatter.rippleEffect"
+  ]
+}

--- a/src/main/java/org/icepear/echarts/EffectScatter.java
+++ b/src/main/java/org/icepear/echarts/EffectScatter.java
@@ -1,0 +1,19 @@
+package org.icepear.echarts;
+
+import java.io.Serializable;
+
+import org.icepear.echarts.charts.effectScatter.EffectScatterSeries;
+
+public class EffectScatter extends CartesianCoordChart<EffectScatter, EffectScatterSeries> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public EffectScatter() {
+        super(EffectScatter.class, EffectScatterSeries.class);
+    }
+
+    @Override
+    protected EffectScatterSeries createSeries() {
+        return new EffectScatterSeries().setType("effectScatter");
+    }
+}

--- a/src/main/java/org/icepear/echarts/charts/effectScatter/EffectScatterDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/effectScatter/EffectScatterDataItem.java
@@ -1,0 +1,145 @@
+package org.icepear.echarts.charts.effectScatter;
+
+import java.io.Serializable;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.effectScatter.EffectScatterDataItemOption;
+import org.icepear.echarts.origin.util.ItemStyleOption;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+@Accessors(chain = true)
+@Data
+public class EffectScatterDataItem implements EffectScatterDataItemOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String symbol;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolSize;
+
+    public EffectScatterDataItem setSymbolSize(Number symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    public EffectScatterDataItem setSymbolSize(Number[] symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    private Number symbolRotate;
+
+    private Boolean symbolKeepAspect;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolOffset;
+
+    public EffectScatterDataItem setSymbolOffset(Number symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    public EffectScatterDataItem setSymbolOffset(Number[] symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    public EffectScatterDataItem setSymbolOffset(String symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    public EffectScatterDataItem setSymbolOffset(String[] symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    private ItemStyleOption itemStyle;
+
+    private SeriesLabelOption label;
+
+    private Object emphasis;
+
+    private Object select;
+
+    private Object blur;
+
+    @Setter(AccessLevel.NONE)
+    private Object id;
+
+    public EffectScatterDataItem setId(Number id) {
+        this.id = id;
+        return this;
+    }
+
+    public EffectScatterDataItem setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object name;
+
+    public EffectScatterDataItem setName(Number name) {
+        this.name = name;
+        return this;
+    }
+
+    public EffectScatterDataItem setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object groupId;
+
+    public EffectScatterDataItem setGroupId(Number groupId) {
+        this.groupId = groupId;
+        return this;
+    }
+
+    public EffectScatterDataItem setGroupId(String groupId) {
+        this.groupId = groupId;
+        return this;
+    }
+
+    private Boolean selected;
+
+    @Setter(AccessLevel.NONE)
+    private Object value;
+
+    public EffectScatterDataItem setValue(Number value) {
+        this.value = value;
+        return this;
+    }
+
+    public EffectScatterDataItem setValue(Number[] value) {
+        this.value = value;
+        return this;
+    }
+
+    public EffectScatterDataItem setValue(Object value) {
+        this.value = value;
+        return this;
+    }
+
+    public EffectScatterDataItem setValue(Object[] value) {
+        this.value = value;
+        return this;
+    }
+
+    public EffectScatterDataItem setValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+    public EffectScatterDataItem setValue(String[] value) {
+        this.value = value;
+        return this;
+    }
+}

--- a/src/main/java/org/icepear/echarts/charts/effectScatter/EffectScatterEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/effectScatter/EffectScatterEmphasis.java
@@ -1,0 +1,29 @@
+package org.icepear.echarts.charts.effectScatter;
+
+import java.io.Serializable;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.effectScatter.EffectScatterEmphasisOption;
+import org.icepear.echarts.origin.util.ItemStyleOption;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+@Accessors(chain = true)
+@Data
+public class EffectScatterEmphasis implements EffectScatterEmphasisOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Boolean disabled;
+
+    private String focus;
+
+    private Boolean scale;
+
+    private ItemStyleOption itemStyle;
+
+    private SeriesLabelOption label;
+
+    private Object blurScope;
+}

--- a/src/main/java/org/icepear/echarts/charts/effectScatter/EffectScatterEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/effectScatter/EffectScatterEmphasis.java
@@ -15,15 +15,15 @@ public class EffectScatterEmphasis implements EffectScatterEmphasisOption, Seria
 
     private static final long serialVersionUID = 1L;
 
-    private Boolean disabled;
-
-    private String focus;
-
-    private Boolean scale;
-
     private ItemStyleOption itemStyle;
 
     private SeriesLabelOption label;
 
     private Object blurScope;
+
+    private String focus;
+
+    private Boolean scale;
+
+    private Boolean disabled;
 }

--- a/src/main/java/org/icepear/echarts/charts/effectScatter/EffectScatterSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/effectScatter/EffectScatterSeries.java
@@ -139,12 +139,12 @@ public class EffectScatterSeries implements EffectScatterSeriesOption, Serializa
     @Setter(AccessLevel.NONE)
     private Object emphasis;
 
-    public EffectScatterSeries setEmphasis(Object emphasis) {
+    public EffectScatterSeries setEmphasis(EffectScatterEmphasisOption emphasis) {
         this.emphasis = emphasis;
         return this;
     }
 
-    public EffectScatterSeries setEmphasis(EffectScatterEmphasisOption emphasis) {
+    public EffectScatterSeries setEmphasis(Object emphasis) {
         this.emphasis = emphasis;
         return this;
     }
@@ -183,6 +183,11 @@ public class EffectScatterSeries implements EffectScatterSeriesOption, Serializa
     @Setter(AccessLevel.NONE)
     private Object data;
 
+    public EffectScatterSeries setData(EffectScatterDataItemOption[] data) {
+        this.data = data;
+        return this;
+    }
+
     public EffectScatterSeries setData(Number[] data) {
         this.data = data;
         return this;
@@ -204,11 +209,6 @@ public class EffectScatterSeries implements EffectScatterSeriesOption, Serializa
     }
 
     public EffectScatterSeries setData(Object[][] data) {
-        this.data = data;
-        return this;
-    }
-
-    public EffectScatterSeries setData(EffectScatterDataItemOption[] data) {
         this.data = data;
         return this;
     }
@@ -386,11 +386,11 @@ public class EffectScatterSeries implements EffectScatterSeriesOption, Serializa
 
     private OptionEncode encode;
 
-    private Boolean clip;
-
     private String effectType;
 
     private String showEffectOn;
 
     private RippleEffectOption rippleEffect;
+
+    private Boolean clip;
 }

--- a/src/main/java/org/icepear/echarts/charts/effectScatter/EffectScatterSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/effectScatter/EffectScatterSeries.java
@@ -1,0 +1,396 @@
+package org.icepear.echarts.charts.effectScatter;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.effectScatter.EffectScatterDataItemOption;
+import org.icepear.echarts.origin.chart.effectScatter.EffectScatterEmphasisOption;
+import org.icepear.echarts.origin.chart.effectScatter.EffectScatterSeriesOption;
+import org.icepear.echarts.origin.chart.effectScatter.RippleEffectOption;
+import org.icepear.echarts.origin.component.marker.MarkAreaOption;
+import org.icepear.echarts.origin.component.marker.MarkLineOption;
+import org.icepear.echarts.origin.component.marker.MarkPointOption;
+import org.icepear.echarts.origin.util.ItemStyleOption;
+import org.icepear.echarts.origin.util.LabelLayoutOption;
+import org.icepear.echarts.origin.util.LabelLineOption;
+import org.icepear.echarts.origin.util.OptionEncode;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+@Accessors(chain = true)
+@Data
+public class EffectScatterSeries implements EffectScatterSeriesOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String mainType;
+
+    private String type = "effectScatter";
+
+    @Setter(AccessLevel.NONE)
+    private Object id;
+
+    public EffectScatterSeries setId(Number id) {
+        this.id = id;
+        return this;
+    }
+
+    public EffectScatterSeries setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object name;
+
+    public EffectScatterSeries setName(Number name) {
+        this.name = name;
+        return this;
+    }
+
+    public EffectScatterSeries setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    private Number z;
+
+    private Number zlevel;
+
+    private Boolean animation;
+
+    private Number animationThreshold;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDuration;
+
+    public EffectScatterSeries setAnimationDuration(Number animationDuration) {
+        this.animationDuration = animationDuration;
+        return this;
+    }
+
+    public EffectScatterSeries setAnimationDuration(Object animationDuration) {
+        this.animationDuration = animationDuration;
+        return this;
+    }
+
+    private Object animationEasing;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDelay;
+
+    public EffectScatterSeries setAnimationDelay(Number animationDelay) {
+        this.animationDelay = animationDelay;
+        return this;
+    }
+
+    public EffectScatterSeries setAnimationDelay(Object animationDelay) {
+        this.animationDelay = animationDelay;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDurationUpdate;
+
+    public EffectScatterSeries setAnimationDurationUpdate(Number animationDurationUpdate) {
+        this.animationDurationUpdate = animationDurationUpdate;
+        return this;
+    }
+
+    public EffectScatterSeries setAnimationDurationUpdate(Object animationDurationUpdate) {
+        this.animationDurationUpdate = animationDurationUpdate;
+        return this;
+    }
+
+    private Object animationEasingUpdate;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDelayUpdate;
+
+    public EffectScatterSeries setAnimationDelayUpdate(Number animationDelayUpdate) {
+        this.animationDelayUpdate = animationDelayUpdate;
+        return this;
+    }
+
+    public EffectScatterSeries setAnimationDelayUpdate(Object animationDelayUpdate) {
+        this.animationDelayUpdate = animationDelayUpdate;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object color;
+
+    public EffectScatterSeries setColor(String color) {
+        this.color = color;
+        return this;
+    }
+
+    public EffectScatterSeries setColor(String[] color) {
+        this.color = color;
+        return this;
+    }
+
+    private String[][] colorLayer;
+
+    @Setter(AccessLevel.NONE)
+    private Object emphasis;
+
+    public EffectScatterSeries setEmphasis(Object emphasis) {
+        this.emphasis = emphasis;
+        return this;
+    }
+
+    public EffectScatterSeries setEmphasis(EffectScatterEmphasisOption emphasis) {
+        this.emphasis = emphasis;
+        return this;
+    }
+
+    private Object select;
+
+    private Object blur;
+
+    private MarkAreaOption markArea;
+
+    private MarkLineOption markLine;
+
+    private MarkPointOption markPoint;
+
+    private Object tooltip;
+
+    private Boolean silent;
+
+    private String blendMode;
+
+    private String cursor;
+
+    @Setter(AccessLevel.NONE)
+    private Object dataGroupId;
+
+    public EffectScatterSeries setDataGroupId(Number dataGroupId) {
+        this.dataGroupId = dataGroupId;
+        return this;
+    }
+
+    public EffectScatterSeries setDataGroupId(String dataGroupId) {
+        this.dataGroupId = dataGroupId;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object data;
+
+    public EffectScatterSeries setData(Number[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public EffectScatterSeries setData(Number[][] data) {
+        this.data = data;
+        return this;
+    }
+
+    public EffectScatterSeries setData(Object data) {
+        this.data = data;
+        return this;
+    }
+
+    public EffectScatterSeries setData(Object[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public EffectScatterSeries setData(Object[][] data) {
+        this.data = data;
+        return this;
+    }
+
+    public EffectScatterSeries setData(EffectScatterDataItemOption[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public EffectScatterSeries setData(String[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public EffectScatterSeries setData(String[][] data) {
+        this.data = data;
+        return this;
+    }
+
+    private String colorBy;
+
+    private Boolean legendHoverLink;
+
+    @Setter(AccessLevel.NONE)
+    private Object progressive;
+
+    public EffectScatterSeries setProgressive(Boolean progressive) {
+        this.progressive = progressive;
+        return this;
+    }
+
+    public EffectScatterSeries setProgressive(Number progressive) {
+        this.progressive = progressive;
+        return this;
+    }
+
+    private Number progressiveThreshold;
+
+    private String progressiveChunkMode;
+
+    private String coordinateSystem;
+
+    private Number hoverLayerThreshold;
+
+    @Setter(AccessLevel.NONE)
+    private Object seriesLayoutBy;
+
+    public EffectScatterSeries setSeriesLayoutBy(Object seriesLayoutBy) {
+        this.seriesLayoutBy = seriesLayoutBy;
+        return this;
+    }
+
+    public EffectScatterSeries setSeriesLayoutBy(String seriesLayoutBy) {
+        this.seriesLayoutBy = seriesLayoutBy;
+        return this;
+    }
+
+    private LabelLineOption labelLine;
+
+    private LabelLayoutOption labelLayout;
+
+    private Object stateAnimation;
+
+    @Setter(AccessLevel.NONE)
+    private Object universalTransition;
+
+    public EffectScatterSeries setUniversalTransition(Boolean universalTransition) {
+        this.universalTransition = universalTransition;
+        return this;
+    }
+
+    public EffectScatterSeries setUniversalTransition(Object universalTransition) {
+        this.universalTransition = universalTransition;
+        return this;
+    }
+
+    private Map<String, Boolean> selectedMap;
+
+    @Setter(AccessLevel.NONE)
+    private Object selectedMode;
+
+    public EffectScatterSeries setSelectedMode(Boolean selectedMode) {
+        this.selectedMode = selectedMode;
+        return this;
+    }
+
+    public EffectScatterSeries setSelectedMode(String selectedMode) {
+        this.selectedMode = selectedMode;
+        return this;
+    }
+
+    private ItemStyleOption itemStyle;
+
+    private SeriesLabelOption label;
+
+    private Number xAxisIndex;
+
+    private Number yAxisIndex;
+
+    private String xAxisId;
+
+    private String yAxisId;
+
+    private Number polarIndex;
+
+    private String polarId;
+
+    private Number calendarIndex;
+
+    private String calendarId;
+
+    private Number geoIndex;
+
+    private String geoId;
+
+    private Number singleAxisIndex;
+
+    private String singleAxisId;
+
+    private String symbol;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolSize;
+
+    public EffectScatterSeries setSymbolSize(Number symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    public EffectScatterSeries setSymbolSize(Number[] symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    private Number symbolRotate;
+
+    private Boolean symbolKeepAspect;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolOffset;
+
+    public EffectScatterSeries setSymbolOffset(Number symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    public EffectScatterSeries setSymbolOffset(Number[] symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    public EffectScatterSeries setSymbolOffset(String symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    public EffectScatterSeries setSymbolOffset(String[] symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    private Number datasetIndex;
+
+    @Setter(AccessLevel.NONE)
+    private Object datasetId;
+
+    public EffectScatterSeries setDatasetId(Number datasetId) {
+        this.datasetId = datasetId;
+        return this;
+    }
+
+    public EffectScatterSeries setDatasetId(String datasetId) {
+        this.datasetId = datasetId;
+        return this;
+    }
+
+    private Object sourceHeader;
+
+    private Object[] dimensions;
+
+    private OptionEncode encode;
+
+    private Boolean clip;
+
+    private String effectType;
+
+    private String showEffectOn;
+
+    private RippleEffectOption rippleEffect;
+}

--- a/src/main/java/org/icepear/echarts/charts/effectScatter/RippleEffect.java
+++ b/src/main/java/org/icepear/echarts/charts/effectScatter/RippleEffect.java
@@ -1,0 +1,25 @@
+package org.icepear.echarts.charts.effectScatter;
+
+import java.io.Serializable;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.effectScatter.RippleEffectOption;
+
+@Accessors(chain = true)
+@Data
+public class RippleEffect implements RippleEffectOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String color;
+
+    private Number number;
+
+    private Number period;
+
+    private Number scale;
+
+    private String brushType;
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/effectScatter/EffectScatterDataItemOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/effectScatter/EffectScatterDataItemOption.java
@@ -1,0 +1,13 @@
+package org.icepear.echarts.origin.chart.effectScatter;
+
+import org.icepear.echarts.origin.util.DefaultOptionDataItemObject;
+import org.icepear.echarts.origin.util.StatesOptionMixin;
+import org.icepear.echarts.origin.util.SymbolOptionMixin;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-effectScatter.data
+ */
+public interface EffectScatterDataItemOption
+        extends SymbolOptionMixin, EffectScatterStateOption, StatesOptionMixin, DefaultOptionDataItemObject {
+
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/effectScatter/EffectScatterEmphasisOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/effectScatter/EffectScatterEmphasisOption.java
@@ -1,0 +1,15 @@
+package org.icepear.echarts.origin.chart.effectScatter;
+
+import org.icepear.echarts.origin.util.EmphasisOption;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-effectScatter.emphasis
+ */
+public interface EffectScatterEmphasisOption extends EffectScatterStateOption, EmphasisOption {
+
+    EffectScatterEmphasisOption setFocus(String focus);
+
+    EffectScatterEmphasisOption setScale(Boolean scale);
+
+    EffectScatterEmphasisOption setDisabled(Boolean disabled);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/effectScatter/EffectScatterSeriesOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/effectScatter/EffectScatterSeriesOption.java
@@ -28,6 +28,8 @@ public interface EffectScatterSeriesOption extends SeriesOption, EffectScatterSt
 
     EffectScatterSeriesOption setClip(Boolean clip);
 
+    EffectScatterSeriesOption setData(EffectScatterDataItemOption[] data);
+
     EffectScatterSeriesOption setData(Number[] data);
 
     EffectScatterSeriesOption setData(Number[][] data);
@@ -35,8 +37,6 @@ public interface EffectScatterSeriesOption extends SeriesOption, EffectScatterSt
     EffectScatterSeriesOption setData(Object[] data);
 
     EffectScatterSeriesOption setData(Object[][] data);
-
-    EffectScatterSeriesOption setData(EffectScatterDataItemOption[] data);
 
     EffectScatterSeriesOption setData(String[] data);
 

--- a/src/main/java/org/icepear/echarts/origin/chart/effectScatter/EffectScatterSeriesOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/effectScatter/EffectScatterSeriesOption.java
@@ -1,0 +1,46 @@
+package org.icepear.echarts.origin.chart.effectScatter;
+
+import org.icepear.echarts.origin.util.SeriesEncodeOptionMixin;
+import org.icepear.echarts.origin.util.SeriesOnCalendarOptionMixin;
+import org.icepear.echarts.origin.util.SeriesOnCartesianOptionMixin;
+import org.icepear.echarts.origin.util.SeriesOnGeoOptionMixin;
+import org.icepear.echarts.origin.util.SeriesOnPolarOptionMixin;
+import org.icepear.echarts.origin.util.SeriesOnSingleOptionMixin;
+import org.icepear.echarts.origin.util.SeriesOption;
+import org.icepear.echarts.origin.util.SymbolOptionMixin;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-effectScatter
+ */
+public interface EffectScatterSeriesOption extends SeriesOption, EffectScatterStateOption,
+        SeriesOnCartesianOptionMixin, SeriesOnPolarOptionMixin, SeriesOnCalendarOptionMixin,
+        SeriesOnGeoOptionMixin, SeriesOnSingleOptionMixin, SymbolOptionMixin, SeriesEncodeOptionMixin {
+
+    EffectScatterSeriesOption setType(String type);
+
+    EffectScatterSeriesOption setCoordinateSystem(String coordinateSystem);
+
+    EffectScatterSeriesOption setEffectType(String effectType);
+
+    EffectScatterSeriesOption setShowEffectOn(String showEffectOn);
+
+    EffectScatterSeriesOption setRippleEffect(RippleEffectOption rippleEffect);
+
+    EffectScatterSeriesOption setClip(Boolean clip);
+
+    EffectScatterSeriesOption setData(Number[] data);
+
+    EffectScatterSeriesOption setData(Number[][] data);
+
+    EffectScatterSeriesOption setData(Object[] data);
+
+    EffectScatterSeriesOption setData(Object[][] data);
+
+    EffectScatterSeriesOption setData(EffectScatterDataItemOption[] data);
+
+    EffectScatterSeriesOption setData(String[] data);
+
+    EffectScatterSeriesOption setData(String[][] data);
+
+    EffectScatterSeriesOption setEmphasis(EffectScatterEmphasisOption emphasis);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/effectScatter/EffectScatterStateOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/effectScatter/EffectScatterStateOption.java
@@ -1,0 +1,15 @@
+package org.icepear.echarts.origin.chart.effectScatter;
+
+import org.icepear.echarts.origin.util.ItemStyleOption;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-effectScatter.itemStyle
+ * https://echarts.apache.org/en/option.html#series-effectScatter.label
+ */
+public interface EffectScatterStateOption {
+
+    EffectScatterStateOption setItemStyle(ItemStyleOption itemStyle);
+
+    EffectScatterStateOption setLabel(SeriesLabelOption label);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/effectScatter/RippleEffectOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/effectScatter/RippleEffectOption.java
@@ -1,0 +1,17 @@
+package org.icepear.echarts.origin.chart.effectScatter;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-effectScatter.rippleEffect
+ */
+public interface RippleEffectOption {
+
+    RippleEffectOption setColor(String color);
+
+    RippleEffectOption setNumber(Number number);
+
+    RippleEffectOption setPeriod(Number period);
+
+    RippleEffectOption setScale(Number scale);
+
+    RippleEffectOption setBrushType(String brushType);
+}

--- a/src/test/java/org/icepear/echarts/charts/effectScatter/EffectScatterSeriesTest.java
+++ b/src/test/java/org/icepear/echarts/charts/effectScatter/EffectScatterSeriesTest.java
@@ -1,0 +1,207 @@
+package org.icepear.echarts.charts.effectScatter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.icepear.echarts.EffectScatter;
+import org.icepear.echarts.Option;
+import org.icepear.echarts.components.series.SeriesLabel;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+/**
+ * Direct unit tests for EffectScatter — exercises every public setter and
+ * verifies the JSON shape, beyond the snapshot in BasicEffectScatterTest.
+ */
+public class EffectScatterSeriesTest {
+
+    private static final EChartsSerializer SERIALIZER = new EChartsSerializer();
+
+    @Test
+    public void testDefaultTypeIsEffectScatter() {
+        assertEquals("effectScatter", new EffectScatterSeries().getType());
+    }
+
+    @Test
+    public void testEffectScatterFactoryProducesCorrectSeries() {
+        EffectScatter chart = new EffectScatter()
+                .addXAxis().addYAxis()
+                .addSeries(new Number[][] { { 1, 2 }, { 3, 4 } });
+        Option option = chart.getOption();
+        JsonElement json = SERIALIZER.toJsonTree(option);
+        JsonObject series = json.getAsJsonObject().get("series").getAsJsonArray()
+                .get(0).getAsJsonObject();
+        assertEquals("effectScatter", series.get("type").getAsString());
+    }
+
+    @Test
+    public void testRippleEffectAllFields() {
+        RippleEffect ripple = new RippleEffect()
+                .setColor("#abc")
+                .setNumber(5)
+                .setPeriod(3)
+                .setScale(2.5)
+                .setBrushType("fill");
+        JsonObject json = SERIALIZER.toJsonTree(ripple).getAsJsonObject();
+        assertEquals("#abc", json.get("color").getAsString());
+        assertEquals(5, json.get("number").getAsInt());
+        assertEquals(3, json.get("period").getAsInt());
+        assertEquals(2.5, json.get("scale").getAsDouble(), 0.0);
+        assertEquals("fill", json.get("brushType").getAsString());
+    }
+
+    @Test
+    public void testRippleEffectOnSeriesNestsCorrectly() {
+        EffectScatterSeries series = new EffectScatterSeries()
+                .setRippleEffect(new RippleEffect().setScale(3).setBrushType("stroke"));
+        JsonObject json = SERIALIZER.toJsonTree(series).getAsJsonObject();
+        JsonObject ripple = json.get("rippleEffect").getAsJsonObject();
+        assertEquals(3, ripple.get("scale").getAsInt());
+        assertEquals("stroke", ripple.get("brushType").getAsString());
+    }
+
+    @Test
+    public void testShowEffectOnAcceptsBothValues() {
+        assertEquals("render", new EffectScatterSeries().setShowEffectOn("render").getShowEffectOn());
+        assertEquals("emphasis", new EffectScatterSeries().setShowEffectOn("emphasis").getShowEffectOn());
+    }
+
+    @Test
+    public void testEffectTypeField() {
+        EffectScatterSeries s = new EffectScatterSeries().setEffectType("ripple");
+        JsonObject json = SERIALIZER.toJsonTree(s).getAsJsonObject();
+        assertEquals("ripple", json.get("effectType").getAsString());
+    }
+
+    @Test
+    public void testSymbolSizeNumberAndArrayOverloads() {
+        EffectScatterSeries scalar = new EffectScatterSeries().setSymbolSize(20);
+        EffectScatterSeries vector = new EffectScatterSeries().setSymbolSize(new Number[] { 10, 20 });
+        assertEquals(20, ((Number) scalar.getSymbolSize()).intValue());
+        assertNotNull(vector.getSymbolSize());
+        assertTrue(vector.getSymbolSize() instanceof Number[]);
+    }
+
+    @Test
+    public void testSymbolOffsetAllOverloads() {
+        EffectScatterSeries n = new EffectScatterSeries().setSymbolOffset(5);
+        EffectScatterSeries na = new EffectScatterSeries().setSymbolOffset(new Number[] { 1, 2 });
+        EffectScatterSeries s = new EffectScatterSeries().setSymbolOffset("50%");
+        EffectScatterSeries sa = new EffectScatterSeries().setSymbolOffset(new String[] { "50%", "0%" });
+        assertNotNull(n.getSymbolOffset());
+        assertNotNull(na.getSymbolOffset());
+        assertNotNull(s.getSymbolOffset());
+        assertNotNull(sa.getSymbolOffset());
+    }
+
+    @Test
+    public void testDataOverloads() {
+        EffectScatterSeries flat = new EffectScatterSeries().setData(new Number[] { 1, 2, 3 });
+        EffectScatterSeries pairs = new EffectScatterSeries().setData(new Number[][] { { 1, 2 }, { 3, 4 } });
+        EffectScatterSeries items = new EffectScatterSeries().setData(new EffectScatterDataItem[] {
+                new EffectScatterDataItem().setName("p1").setValue(new Number[] { 1, 2 })
+        });
+        assertNotNull(flat.getData());
+        assertNotNull(pairs.getData());
+        assertNotNull(items.getData());
+    }
+
+    @Test
+    public void testDataItemSerialization() {
+        EffectScatterDataItem item = new EffectScatterDataItem()
+                .setName("hotspot-1")
+                .setValue(new Number[] { 10, 20 })
+                .setSymbolSize(30)
+                .setSelected(true);
+        JsonObject json = SERIALIZER.toJsonTree(item).getAsJsonObject();
+        assertEquals("hotspot-1", json.get("name").getAsString());
+        assertEquals(30, json.get("symbolSize").getAsInt());
+        assertEquals(true, json.get("selected").getAsBoolean());
+        assertEquals(2, json.get("value").getAsJsonArray().size());
+    }
+
+    @Test
+    public void testEmphasisFocusAndScale() {
+        EffectScatterEmphasis e = new EffectScatterEmphasis()
+                .setFocus("series")
+                .setScale(true)
+                .setLabel(new SeriesLabel().setShow(true));
+        JsonObject json = SERIALIZER.toJsonTree(e).getAsJsonObject();
+        assertEquals("series", json.get("focus").getAsString());
+        assertEquals(true, json.get("scale").getAsBoolean());
+        assertEquals(true, json.get("label").getAsJsonObject().get("show").getAsBoolean());
+    }
+
+    @Test
+    public void testEmphasisDisabled() {
+        JsonObject json = SERIALIZER.toJsonTree(
+                new EffectScatterEmphasis().setDisabled(true)).getAsJsonObject();
+        assertEquals(true, json.get("disabled").getAsBoolean());
+    }
+
+    @Test
+    public void testCoordinateSystemAndAxisIndices() {
+        EffectScatterSeries s = new EffectScatterSeries()
+                .setCoordinateSystem("polar")
+                .setPolarIndex(0)
+                .setXAxisIndex(1)
+                .setYAxisIndex(2);
+        JsonObject json = SERIALIZER.toJsonTree(s).getAsJsonObject();
+        assertEquals("polar", json.get("coordinateSystem").getAsString());
+        assertEquals(0, json.get("polarIndex").getAsInt());
+        assertEquals(1, json.get("xAxisIndex").getAsInt());
+        assertEquals(2, json.get("yAxisIndex").getAsInt());
+    }
+
+    @Test
+    public void testNullableFieldsAreOmitted() {
+        JsonObject json = SERIALIZER.toJsonTree(new EffectScatterSeries()).getAsJsonObject();
+        assertEquals("effectScatter", json.get("type").getAsString());
+        assertNull(json.get("rippleEffect"));
+        assertNull(json.get("data"));
+        assertNull(json.get("symbol"));
+    }
+
+    @Test
+    public void testParsedJsonRoundTrips() {
+        EffectScatterSeries s = new EffectScatterSeries()
+                .setData(new Number[][] { { 1, 2 }, { 3, 4 } })
+                .setRippleEffect(new RippleEffect().setScale(2));
+        String json = SERIALIZER.toJson(s);
+        JsonElement parsed = JsonParser.parseString(json);
+        assertEquals(parsed, JsonParser.parseString(SERIALIZER.toJson(s)));
+    }
+
+    @Test
+    public void testChartChainable() {
+        EffectScatter chart = new EffectScatter()
+                .setTitle("My Effect Scatter")
+                .setLegend()
+                .addXAxis().addYAxis()
+                .addSeries(new EffectScatterSeries().setData(new Number[] { 1, 2, 3 }));
+        Option o = chart.getOption();
+        assertNotNull(o.getTitle());
+        assertNotNull(o.getLegend());
+        assertNotNull(o.getSeries());
+    }
+
+    @Test
+    public void testGeoIndexAndIdSerialization() {
+        EffectScatterSeries s = new EffectScatterSeries().setGeoIndex(0).setGeoId("geo-1");
+        JsonObject json = SERIALIZER.toJsonTree(s).getAsJsonObject();
+        assertEquals(0, json.get("geoIndex").getAsInt());
+        assertEquals("geo-1", json.get("geoId").getAsString());
+    }
+
+    @Test
+    public void testClipFlag() {
+        JsonObject json = SERIALIZER.toJsonTree(new EffectScatterSeries().setClip(false)).getAsJsonObject();
+        assertEquals(false, json.get("clip").getAsBoolean());
+    }
+}

--- a/src/test/java/org/icepear/echarts/demo/EffectScatterDemo.java
+++ b/src/test/java/org/icepear/echarts/demo/EffectScatterDemo.java
@@ -1,0 +1,66 @@
+package org.icepear.echarts.demo;
+
+import java.io.FileWriter;
+import java.io.Writer;
+
+import org.icepear.echarts.EffectScatter;
+import org.icepear.echarts.charts.effectScatter.EffectScatterDataItem;
+import org.icepear.echarts.charts.effectScatter.EffectScatterSeries;
+import org.icepear.echarts.charts.effectScatter.RippleEffect;
+import org.icepear.echarts.components.title.Title;
+import org.icepear.echarts.components.tooltip.Tooltip;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+/**
+ * Local-only demo: writes /tmp/effect-scatter-demo.html.
+ *
+ * Run: mvn test -Dtest=EffectScatterDemo
+ * Then: open /tmp/effect-scatter-demo.html
+ */
+public class EffectScatterDemo {
+
+    @Test
+    public void writeDemoHtml() throws Exception {
+        EffectScatterDataItem[] data = new EffectScatterDataItem[] {
+                new EffectScatterDataItem().setName("San Francisco").setValue(new Number[] { 12, 78 }).setSymbolSize(28),
+                new EffectScatterDataItem().setName("Los Angeles").setValue(new Number[] { 22, 60 }).setSymbolSize(34),
+                new EffectScatterDataItem().setName("Seattle").setValue(new Number[] { 14, 90 }).setSymbolSize(20),
+                new EffectScatterDataItem().setName("Austin").setValue(new Number[] { 55, 50 }).setSymbolSize(26),
+                new EffectScatterDataItem().setName("New York").setValue(new Number[] { 90, 80 }).setSymbolSize(40),
+                new EffectScatterDataItem().setName("Miami").setValue(new Number[] { 88, 25 }).setSymbolSize(22),
+                new EffectScatterDataItem().setName("Chicago").setValue(new Number[] { 70, 75 }).setSymbolSize(30),
+                new EffectScatterDataItem().setName("Denver").setValue(new Number[] { 45, 70 }).setSymbolSize(24)
+        };
+
+        EffectScatter chart = new EffectScatter()
+                .setTitle(new Title().setText("Active Incident Hotspots").setLeft("center"))
+                .setTooltip(new Tooltip().setTrigger("item"))
+                .addXAxis()
+                .addYAxis()
+                .addSeries(new EffectScatterSeries()
+                        .setName("Live Reports")
+                        .setShowEffectOn("render")
+                        .setRippleEffect(new RippleEffect()
+                                .setScale(3)
+                                .setBrushType("stroke")
+                                .setPeriod(4))
+                        .setData(data));
+
+        String optionJson = new EChartsSerializer().toJson(chart.getOption());
+
+        String html = "<!doctype html><html><head><meta charset='utf-8'><title>EffectScatter Demo</title>"
+                + "<script src='https://cdnjs.cloudflare.com/ajax/libs/echarts/5.4.3/echarts.min.js'></script>"
+                + "<style>html,body,#chart{margin:0;width:100%;height:100vh;background:#0b1220;color:#fff}</style>"
+                + "</head><body><div id='chart'></div><script>"
+                + "const chart = echarts.init(document.getElementById('chart'),'dark');"
+                + "chart.setOption(" + optionJson + ");"
+                + "window.addEventListener('resize', () => chart.resize());"
+                + "</script></body></html>";
+
+        try (Writer w = new FileWriter("/tmp/effect-scatter-demo.html")) {
+            w.write(html);
+        }
+        System.out.println("\n>>> Wrote /tmp/effect-scatter-demo.html — open it in a browser.\n");
+    }
+}

--- a/src/test/java/org/icepear/echarts/render/simple/RenderEffectScatterByChartTest.java
+++ b/src/test/java/org/icepear/echarts/render/simple/RenderEffectScatterByChartTest.java
@@ -1,0 +1,47 @@
+package org.icepear.echarts.render.simple;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.icepear.echarts.Chart;
+import org.icepear.echarts.EffectScatter;
+import org.icepear.echarts.charts.effectScatter.EffectScatterSeries;
+import org.icepear.echarts.charts.effectScatter.RippleEffect;
+import org.icepear.echarts.render.Engine;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RenderEffectScatterByChartTest {
+    private Chart<?, ?> chart;
+
+    @Before
+    public void constructChart() {
+        this.chart = new EffectScatter()
+                .setTitle("Pulse Map")
+                .addXAxis().addYAxis()
+                .addSeries(new EffectScatterSeries()
+                        .setSymbolSize(20)
+                        .setShowEffectOn("render")
+                        .setRippleEffect(new RippleEffect().setScale(2.5).setBrushType("stroke"))
+                        .setData(new Number[][] { { 10, 80 }, { 30, 70 }, { 50, 90 } }));
+    }
+
+    @Test
+    public void testRenderEffectScatterJsonOption() {
+        Engine engine = new Engine();
+        String json = engine.renderJsonOption(chart);
+        assertNotNull(json);
+        assertTrue(json.contains("\"type\":\"effectScatter\""));
+        assertTrue(json.contains("\"rippleEffect\""));
+        assertTrue(json.contains("\"showEffectOn\":\"render\""));
+    }
+
+    @Test
+    public void testRenderEffectScatterHtml() {
+        Engine engine = new Engine();
+        String html = engine.renderHtml(chart);
+        assertNotNull(html);
+        assertTrue(html.contains("setOption"));
+        assertTrue(html.contains("\"type\":\"effectScatter\""));
+    }
+}

--- a/src/test/java/org/icepear/echarts/simple/effectScatter/BasicEffectScatterTest.java
+++ b/src/test/java/org/icepear/echarts/simple/effectScatter/BasicEffectScatterTest.java
@@ -1,0 +1,38 @@
+package org.icepear.echarts.simple.effectScatter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import org.icepear.echarts.EffectScatter;
+import org.icepear.echarts.charts.effectScatter.EffectScatterSeries;
+import org.icepear.echarts.charts.effectScatter.RippleEffect;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+public class BasicEffectScatterTest {
+
+    @Test
+    public void testBasicEffectScatter() {
+        EffectScatter chart = new EffectScatter()
+                .addXAxis()
+                .addYAxis()
+                .addSeries(new EffectScatterSeries()
+                        .setSymbolSize(20)
+                        .setShowEffectOn("render")
+                        .setRippleEffect(new RippleEffect().setScale(2.5).setBrushType("stroke"))
+                        .setData(new Number[][] {
+                                { 10, 80 }, { 20, 50 }, { 30, 70 }, { 40, 30 }, { 50, 90 }
+                        }));
+
+        Reader reader = new InputStreamReader(
+                this.getClass().getResourceAsStream("/simple/effectScatter/basic-effect-scatter.json"));
+        JsonElement expected = JsonParser.parseReader(reader);
+        JsonElement actual = new EChartsSerializer().toJsonTree(chart.getOption());
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/resources/simple/effectScatter/basic-effect-scatter.json
+++ b/src/test/resources/simple/effectScatter/basic-effect-scatter.json
@@ -1,0 +1,19 @@
+{
+  "xAxis": [{ "type": "value" }],
+  "yAxis": [{ "type": "value" }],
+  "series": [
+    {
+      "type": "effectScatter",
+      "data": [
+        [10, 80],
+        [20, 50],
+        [30, 70],
+        [40, 30],
+        [50, 90]
+      ],
+      "symbolSize": 20,
+      "showEffectOn": "render",
+      "rippleEffect": { "scale": 2.5, "brushType": "stroke" }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds the **effectScatter** series — scatter points that pulse with a configurable ripple animation. Most common use: highlight hotspots on a map or any 2D plot.
- Mirrors the existing `Scatter` structure (same `CartesianCoordChart` base, same coordinate-system mixins: cartesian / polar / geo / calendar / single).
- Adds the chart-specific extras: `RippleEffect` (period, scale, brushType, color, number), plus `showEffectOn` (`"render"` / `"emphasis"`) and `effectType` on the series.

## Public API added
- `EffectScatter`
- `charts.effectScatter.EffectScatterSeries`, `EffectScatterDataItem`, `EffectScatterEmphasis`, `RippleEffect`
- `origin.chart.effectScatter.EffectScatterSeriesOption`, `EffectScatterStateOption`, `EffectScatterEmphasisOption`, `EffectScatterDataItemOption`, `RippleEffectOption`

## How to use

```java
EffectScatter chart = new EffectScatter()
    .setTitle("Active hotspots")
    .addXAxis().addYAxis()
    .addSeries(new EffectScatterSeries()
        .setSymbolSize(20)
        .setShowEffectOn("render")
        .setRippleEffect(new RippleEffect().setScale(2.5).setBrushType("stroke"))
        .setData(new Number[][] { {10, 80}, {20, 50}, {30, 70}, {40, 30}, {50, 90} }));

String json = new EChartsSerializer().toJson(chart.getOption());
```

For a richer example with named data items, tooltip, and dark background, see `src/test/java/org/icepear/echarts/demo/EffectScatterDemo.java` — run `mvn test -Dtest=EffectScatterDemo` then `open /tmp/effect-scatter-demo.html`.

## Tests added (22 new, all passing locally)
- `simple/effectScatter/BasicEffectScatterTest` — snapshot test
- `charts/effectScatter/EffectScatterSeriesTest` — 18 unit tests covering every setter overload (symbolSize/symbolOffset Number/String, all data-shape overloads), ripple nesting, null-omission semantics, axis-index/coord-system fields, emphasis flags
- `render/simple/RenderEffectScatterByChartTest` — Engine smoke test (json + html paths)
- `demo/EffectScatterDemo` — opt-in HTML writer for visual inspection

## Test plan
- [x] `mvn test -Dtest=BasicEffectScatterTest` — 1/1 pass
- [x] `mvn test -Dtest=EffectScatterSeriesTest` — 18/18 pass
- [x] `mvn test -Dtest=RenderEffectScatterByChartTest` — 2/2 pass
- [x] `mvn test -Dtest=EffectScatterDemo` then `open /tmp/effect-scatter-demo.html` — pulses render correctly in browser
- [x] `mvn test` (full suite) — all 21 new default-suite tests pass; only the 3 pre-existing polar/float-precision failures remain on master

https://github.com/user-attachments/assets/587f7d91-c0bc-4d0a-8d39-ede8b629b777
