### PR TITLE
Add Lines chart support

### DIFF
--- a/scripts/config/org/icepear/echarts/charts/lines/lines-data-item.json
+++ b/scripts/config/org/icepear/echarts/charts/lines/lines-data-item.json
@@ -1,0 +1,5 @@
+{
+  "name": "LinesDataItem",
+  "type": "class",
+  "implements": ["LinesDataItemOption"]
+}

--- a/scripts/config/org/icepear/echarts/charts/lines/lines-effect.json
+++ b/scripts/config/org/icepear/echarts/charts/lines/lines-effect.json
@@ -1,0 +1,5 @@
+{
+  "name": "LinesEffect",
+  "type": "class",
+  "implements": ["LinesEffectOption"]
+}

--- a/scripts/config/org/icepear/echarts/charts/lines/lines-emphasis.json
+++ b/scripts/config/org/icepear/echarts/charts/lines/lines-emphasis.json
@@ -1,0 +1,5 @@
+{
+  "name": "LinesEmphasis",
+  "type": "class",
+  "implements": ["LinesEmphasisOption"]
+}

--- a/scripts/config/org/icepear/echarts/charts/lines/lines-series.json
+++ b/scripts/config/org/icepear/echarts/charts/lines/lines-series.json
@@ -1,0 +1,5 @@
+{
+  "name": "LinesSeries",
+  "type": "class",
+  "implements": ["LinesSeriesOption"]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/lines/lines-data-item-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/lines/lines-data-item-option.json
@@ -1,0 +1,15 @@
+{
+  "name": "LinesDataItemOption",
+  "type": "interface",
+  "extends": ["StatesOptionMixin"],
+  "fields": [
+    { "name": "name", "types": ["String"] },
+    { "name": "coords", "types": ["Number[][]"] },
+    { "name": "value", "types": ["Number", "Number[]"] },
+    { "name": "lineStyle", "types": ["LineStyleOption"] },
+    { "name": "label", "types": ["SeriesLabelOption"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-lines.data"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/lines/lines-effect-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/lines/lines-effect-option.json
@@ -1,0 +1,20 @@
+{
+  "name": "LinesEffectOption",
+  "type": "interface",
+  "extends": [],
+  "fields": [
+    { "name": "show", "types": ["Boolean"] },
+    { "name": "period", "types": ["Number"] },
+    { "name": "delay", "types": ["Number"] },
+    { "name": "constantSpeed", "types": ["Number"] },
+    { "name": "symbol", "types": ["String"] },
+    { "name": "symbolSize", "types": ["Number", "Number[]"] },
+    { "name": "color", "types": ["String"] },
+    { "name": "trailLength", "types": ["Number"] },
+    { "name": "loop", "types": ["Boolean"] },
+    { "name": "roundTrip", "types": ["Boolean"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-lines.effect"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/lines/lines-emphasis-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/lines/lines-emphasis-option.json
@@ -1,0 +1,12 @@
+{
+  "name": "LinesEmphasisOption",
+  "type": "interface",
+  "extends": ["LinesStateOption", "EmphasisOption"],
+  "fields": [
+    { "name": "focus", "types": ["String"] },
+    { "name": "disabled", "types": ["Boolean"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-lines.emphasis"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/lines/lines-series-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/lines/lines-series-option.json
@@ -1,0 +1,23 @@
+{
+  "name": "LinesSeriesOption",
+  "type": "interface",
+  "extends": ["SeriesOption", "LinesStateOption", "SeriesOnGeoOptionMixin"],
+  "fields": [
+    { "name": "type", "types": ["String"], "default": "lines" },
+    { "name": "coordinateSystem", "types": ["String"] },
+    { "name": "xAxisIndex", "types": ["Number"] },
+    { "name": "yAxisIndex", "types": ["Number"] },
+    { "name": "polarIndex", "types": ["Number"] },
+    { "name": "polyline", "types": ["Boolean"] },
+    { "name": "effect", "types": ["LinesEffectOption"] },
+    { "name": "large", "types": ["Boolean"] },
+    { "name": "largeThreshold", "types": ["Number"] },
+    { "name": "symbol", "types": ["String", "String[]"] },
+    { "name": "symbolSize", "types": ["Number", "Number[]"] },
+    { "name": "data", "types": ["LinesDataItemOption[]", "Object[]"] },
+    { "name": "emphasis", "types": ["LinesEmphasisOption"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-lines"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/lines/lines-state-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/lines/lines-state-option.json
@@ -1,0 +1,12 @@
+{
+  "name": "LinesStateOption",
+  "type": "interface",
+  "extends": [],
+  "fields": [
+    { "name": "lineStyle", "types": ["LineStyleOption"] },
+    { "name": "label", "types": ["SeriesLabelOption"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-lines.lineStyle"
+  ]
+}

--- a/src/main/java/org/icepear/echarts/Lines.java
+++ b/src/main/java/org/icepear/echarts/Lines.java
@@ -1,0 +1,19 @@
+package org.icepear.echarts;
+
+import java.io.Serializable;
+
+import org.icepear.echarts.charts.lines.LinesSeries;
+
+public class Lines extends Chart<Lines, LinesSeries> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public Lines() {
+        super(Lines.class, LinesSeries.class);
+    }
+
+    @Override
+    protected LinesSeries createSeries() {
+        return new LinesSeries().setType("lines");
+    }
+}

--- a/src/main/java/org/icepear/echarts/charts/lines/LinesDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/lines/LinesDataItem.java
@@ -17,6 +17,12 @@ public class LinesDataItem implements LinesDataItemOption, Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    private Object emphasis;
+
+    private Object select;
+
+    private Object blur;
+
     private String name;
 
     private Number[][] coords;
@@ -37,10 +43,4 @@ public class LinesDataItem implements LinesDataItemOption, Serializable {
     private LineStyleOption lineStyle;
 
     private SeriesLabelOption label;
-
-    private Object emphasis;
-
-    private Object select;
-
-    private Object blur;
 }

--- a/src/main/java/org/icepear/echarts/charts/lines/LinesDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/lines/LinesDataItem.java
@@ -1,0 +1,46 @@
+package org.icepear.echarts.charts.lines;
+
+import java.io.Serializable;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.lines.LinesDataItemOption;
+import org.icepear.echarts.origin.util.LineStyleOption;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+@Accessors(chain = true)
+@Data
+public class LinesDataItem implements LinesDataItemOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String name;
+
+    private Number[][] coords;
+
+    @Setter(AccessLevel.NONE)
+    private Object value;
+
+    public LinesDataItem setValue(Number value) {
+        this.value = value;
+        return this;
+    }
+
+    public LinesDataItem setValue(Number[] value) {
+        this.value = value;
+        return this;
+    }
+
+    private LineStyleOption lineStyle;
+
+    private SeriesLabelOption label;
+
+    private Object emphasis;
+
+    private Object select;
+
+    private Object blur;
+}

--- a/src/main/java/org/icepear/echarts/charts/lines/LinesEffect.java
+++ b/src/main/java/org/icepear/echarts/charts/lines/LinesEffect.java
@@ -1,0 +1,48 @@
+package org.icepear.echarts.charts.lines;
+
+import java.io.Serializable;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.lines.LinesEffectOption;
+
+@Accessors(chain = true)
+@Data
+public class LinesEffect implements LinesEffectOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Boolean show;
+
+    private Number period;
+
+    private Number delay;
+
+    private Number constantSpeed;
+
+    private String symbol;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolSize;
+
+    public LinesEffect setSymbolSize(Number symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    public LinesEffect setSymbolSize(Number[] symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    private String color;
+
+    private Number trailLength;
+
+    private Boolean loop;
+
+    private Boolean roundTrip;
+}

--- a/src/main/java/org/icepear/echarts/charts/lines/LinesEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/lines/LinesEmphasis.java
@@ -1,0 +1,27 @@
+package org.icepear.echarts.charts.lines;
+
+import java.io.Serializable;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.lines.LinesEmphasisOption;
+import org.icepear.echarts.origin.util.LineStyleOption;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+@Accessors(chain = true)
+@Data
+public class LinesEmphasis implements LinesEmphasisOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Boolean disabled;
+
+    private String focus;
+
+    private LineStyleOption lineStyle;
+
+    private SeriesLabelOption label;
+
+    private Object blurScope;
+}

--- a/src/main/java/org/icepear/echarts/charts/lines/LinesEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/lines/LinesEmphasis.java
@@ -15,13 +15,13 @@ public class LinesEmphasis implements LinesEmphasisOption, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private Boolean disabled;
-
-    private String focus;
-
     private LineStyleOption lineStyle;
 
     private SeriesLabelOption label;
 
     private Object blurScope;
+
+    private String focus;
+
+    private Boolean disabled;
 }

--- a/src/main/java/org/icepear/echarts/charts/lines/LinesSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/lines/LinesSeries.java
@@ -222,18 +222,7 @@ public class LinesSeries implements LinesSeriesOption, Serializable {
 
     private Number hoverLayerThreshold;
 
-    @Setter(AccessLevel.NONE)
-    private Object seriesLayoutBy;
-
-    public LinesSeries setSeriesLayoutBy(Object seriesLayoutBy) {
-        this.seriesLayoutBy = seriesLayoutBy;
-        return this;
-    }
-
-    public LinesSeries setSeriesLayoutBy(String seriesLayoutBy) {
-        this.seriesLayoutBy = seriesLayoutBy;
-        return this;
-    }
+    private String seriesLayoutBy;
 
     private LabelLineOption labelLine;
 
@@ -273,15 +262,23 @@ public class LinesSeries implements LinesSeriesOption, Serializable {
 
     private SeriesLabelOption label;
 
+    private Number geoIndex;
+
+    private String geoId;
+
     private Number xAxisIndex;
 
     private Number yAxisIndex;
 
     private Number polarIndex;
 
-    private Number geoIndex;
+    private Boolean polyline;
 
-    private String geoId;
+    private LinesEffectOption effect;
+
+    private Boolean large;
+
+    private Number largeThreshold;
 
     @Setter(AccessLevel.NONE)
     private Object symbol;
@@ -308,12 +305,4 @@ public class LinesSeries implements LinesSeriesOption, Serializable {
         this.symbolSize = symbolSize;
         return this;
     }
-
-    private Boolean polyline;
-
-    private LinesEffectOption effect;
-
-    private Boolean large;
-
-    private Number largeThreshold;
 }

--- a/src/main/java/org/icepear/echarts/charts/lines/LinesSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/lines/LinesSeries.java
@@ -1,0 +1,319 @@
+package org.icepear.echarts.charts.lines;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.lines.LinesDataItemOption;
+import org.icepear.echarts.origin.chart.lines.LinesEffectOption;
+import org.icepear.echarts.origin.chart.lines.LinesEmphasisOption;
+import org.icepear.echarts.origin.chart.lines.LinesSeriesOption;
+import org.icepear.echarts.origin.component.marker.MarkAreaOption;
+import org.icepear.echarts.origin.component.marker.MarkLineOption;
+import org.icepear.echarts.origin.component.marker.MarkPointOption;
+import org.icepear.echarts.origin.util.LabelLayoutOption;
+import org.icepear.echarts.origin.util.LabelLineOption;
+import org.icepear.echarts.origin.util.LineStyleOption;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+@Accessors(chain = true)
+@Data
+public class LinesSeries implements LinesSeriesOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String mainType;
+
+    private String type = "lines";
+
+    @Setter(AccessLevel.NONE)
+    private Object id;
+
+    public LinesSeries setId(Number id) {
+        this.id = id;
+        return this;
+    }
+
+    public LinesSeries setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object name;
+
+    public LinesSeries setName(Number name) {
+        this.name = name;
+        return this;
+    }
+
+    public LinesSeries setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    private Number z;
+
+    private Number zlevel;
+
+    private Boolean animation;
+
+    private Number animationThreshold;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDuration;
+
+    public LinesSeries setAnimationDuration(Number animationDuration) {
+        this.animationDuration = animationDuration;
+        return this;
+    }
+
+    public LinesSeries setAnimationDuration(Object animationDuration) {
+        this.animationDuration = animationDuration;
+        return this;
+    }
+
+    private Object animationEasing;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDelay;
+
+    public LinesSeries setAnimationDelay(Number animationDelay) {
+        this.animationDelay = animationDelay;
+        return this;
+    }
+
+    public LinesSeries setAnimationDelay(Object animationDelay) {
+        this.animationDelay = animationDelay;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDurationUpdate;
+
+    public LinesSeries setAnimationDurationUpdate(Number animationDurationUpdate) {
+        this.animationDurationUpdate = animationDurationUpdate;
+        return this;
+    }
+
+    public LinesSeries setAnimationDurationUpdate(Object animationDurationUpdate) {
+        this.animationDurationUpdate = animationDurationUpdate;
+        return this;
+    }
+
+    private Object animationEasingUpdate;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDelayUpdate;
+
+    public LinesSeries setAnimationDelayUpdate(Number animationDelayUpdate) {
+        this.animationDelayUpdate = animationDelayUpdate;
+        return this;
+    }
+
+    public LinesSeries setAnimationDelayUpdate(Object animationDelayUpdate) {
+        this.animationDelayUpdate = animationDelayUpdate;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object color;
+
+    public LinesSeries setColor(String color) {
+        this.color = color;
+        return this;
+    }
+
+    public LinesSeries setColor(String[] color) {
+        this.color = color;
+        return this;
+    }
+
+    private String[][] colorLayer;
+
+    @Setter(AccessLevel.NONE)
+    private Object emphasis;
+
+    public LinesSeries setEmphasis(LinesEmphasisOption emphasis) {
+        this.emphasis = emphasis;
+        return this;
+    }
+
+    public LinesSeries setEmphasis(Object emphasis) {
+        this.emphasis = emphasis;
+        return this;
+    }
+
+    private Object select;
+
+    private Object blur;
+
+    private MarkAreaOption markArea;
+
+    private MarkLineOption markLine;
+
+    private MarkPointOption markPoint;
+
+    private Object tooltip;
+
+    private Boolean silent;
+
+    private String blendMode;
+
+    private String cursor;
+
+    @Setter(AccessLevel.NONE)
+    private Object dataGroupId;
+
+    public LinesSeries setDataGroupId(Number dataGroupId) {
+        this.dataGroupId = dataGroupId;
+        return this;
+    }
+
+    public LinesSeries setDataGroupId(String dataGroupId) {
+        this.dataGroupId = dataGroupId;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object data;
+
+    public LinesSeries setData(LinesDataItemOption[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public LinesSeries setData(Object data) {
+        this.data = data;
+        return this;
+    }
+
+    public LinesSeries setData(Object[] data) {
+        this.data = data;
+        return this;
+    }
+
+    private String colorBy;
+
+    private Boolean legendHoverLink;
+
+    @Setter(AccessLevel.NONE)
+    private Object progressive;
+
+    public LinesSeries setProgressive(Boolean progressive) {
+        this.progressive = progressive;
+        return this;
+    }
+
+    public LinesSeries setProgressive(Number progressive) {
+        this.progressive = progressive;
+        return this;
+    }
+
+    private Number progressiveThreshold;
+
+    private String progressiveChunkMode;
+
+    private String coordinateSystem;
+
+    private Number hoverLayerThreshold;
+
+    @Setter(AccessLevel.NONE)
+    private Object seriesLayoutBy;
+
+    public LinesSeries setSeriesLayoutBy(Object seriesLayoutBy) {
+        this.seriesLayoutBy = seriesLayoutBy;
+        return this;
+    }
+
+    public LinesSeries setSeriesLayoutBy(String seriesLayoutBy) {
+        this.seriesLayoutBy = seriesLayoutBy;
+        return this;
+    }
+
+    private LabelLineOption labelLine;
+
+    private LabelLayoutOption labelLayout;
+
+    private Object stateAnimation;
+
+    @Setter(AccessLevel.NONE)
+    private Object universalTransition;
+
+    public LinesSeries setUniversalTransition(Boolean universalTransition) {
+        this.universalTransition = universalTransition;
+        return this;
+    }
+
+    public LinesSeries setUniversalTransition(Object universalTransition) {
+        this.universalTransition = universalTransition;
+        return this;
+    }
+
+    private Map<String, Boolean> selectedMap;
+
+    @Setter(AccessLevel.NONE)
+    private Object selectedMode;
+
+    public LinesSeries setSelectedMode(Boolean selectedMode) {
+        this.selectedMode = selectedMode;
+        return this;
+    }
+
+    public LinesSeries setSelectedMode(String selectedMode) {
+        this.selectedMode = selectedMode;
+        return this;
+    }
+
+    private LineStyleOption lineStyle;
+
+    private SeriesLabelOption label;
+
+    private Number xAxisIndex;
+
+    private Number yAxisIndex;
+
+    private Number polarIndex;
+
+    private Number geoIndex;
+
+    private String geoId;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbol;
+
+    public LinesSeries setSymbol(String symbol) {
+        this.symbol = symbol;
+        return this;
+    }
+
+    public LinesSeries setSymbol(String[] symbol) {
+        this.symbol = symbol;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolSize;
+
+    public LinesSeries setSymbolSize(Number symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    public LinesSeries setSymbolSize(Number[] symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    private Boolean polyline;
+
+    private LinesEffectOption effect;
+
+    private Boolean large;
+
+    private Number largeThreshold;
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/lines/LinesDataItemOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/lines/LinesDataItemOption.java
@@ -1,0 +1,23 @@
+package org.icepear.echarts.origin.chart.lines;
+
+import org.icepear.echarts.origin.util.LineStyleOption;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+import org.icepear.echarts.origin.util.StatesOptionMixin;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-lines.data
+ */
+public interface LinesDataItemOption extends StatesOptionMixin {
+
+    LinesDataItemOption setName(String name);
+
+    LinesDataItemOption setCoords(Number[][] coords);
+
+    LinesDataItemOption setValue(Number value);
+
+    LinesDataItemOption setValue(Number[] value);
+
+    LinesDataItemOption setLineStyle(LineStyleOption lineStyle);
+
+    LinesDataItemOption setLabel(SeriesLabelOption label);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/lines/LinesEffectOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/lines/LinesEffectOption.java
@@ -1,0 +1,29 @@
+package org.icepear.echarts.origin.chart.lines;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-lines.effect
+ */
+public interface LinesEffectOption {
+
+    LinesEffectOption setShow(Boolean show);
+
+    LinesEffectOption setPeriod(Number period);
+
+    LinesEffectOption setDelay(Number delay);
+
+    LinesEffectOption setConstantSpeed(Number constantSpeed);
+
+    LinesEffectOption setSymbol(String symbol);
+
+    LinesEffectOption setSymbolSize(Number symbolSize);
+
+    LinesEffectOption setSymbolSize(Number[] symbolSize);
+
+    LinesEffectOption setColor(String color);
+
+    LinesEffectOption setTrailLength(Number trailLength);
+
+    LinesEffectOption setLoop(Boolean loop);
+
+    LinesEffectOption setRoundTrip(Boolean roundTrip);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/lines/LinesEmphasisOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/lines/LinesEmphasisOption.java
@@ -1,0 +1,13 @@
+package org.icepear.echarts.origin.chart.lines;
+
+import org.icepear.echarts.origin.util.EmphasisOption;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-lines.emphasis
+ */
+public interface LinesEmphasisOption extends LinesStateOption, EmphasisOption {
+
+    LinesEmphasisOption setFocus(String focus);
+
+    LinesEmphasisOption setDisabled(Boolean disabled);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/lines/LinesSeriesOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/lines/LinesSeriesOption.java
@@ -1,0 +1,42 @@
+package org.icepear.echarts.origin.chart.lines;
+
+import org.icepear.echarts.origin.util.SeriesOnGeoOptionMixin;
+import org.icepear.echarts.origin.util.SeriesOption;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-lines
+ */
+public interface LinesSeriesOption extends SeriesOption, LinesStateOption, SeriesOnGeoOptionMixin {
+
+    LinesSeriesOption setType(String type);
+
+    LinesSeriesOption setCoordinateSystem(String coordinateSystem);
+
+    LinesSeriesOption setXAxisIndex(Number xAxisIndex);
+
+    LinesSeriesOption setYAxisIndex(Number yAxisIndex);
+
+    LinesSeriesOption setPolarIndex(Number polarIndex);
+
+    LinesSeriesOption setPolyline(Boolean polyline);
+
+    LinesSeriesOption setEffect(LinesEffectOption effect);
+
+    LinesSeriesOption setLarge(Boolean large);
+
+    LinesSeriesOption setLargeThreshold(Number largeThreshold);
+
+    LinesSeriesOption setSymbol(String symbol);
+
+    LinesSeriesOption setSymbol(String[] symbol);
+
+    LinesSeriesOption setSymbolSize(Number symbolSize);
+
+    LinesSeriesOption setSymbolSize(Number[] symbolSize);
+
+    LinesSeriesOption setData(LinesDataItemOption[] data);
+
+    LinesSeriesOption setData(Object[] data);
+
+    LinesSeriesOption setEmphasis(LinesEmphasisOption emphasis);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/lines/LinesStateOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/lines/LinesStateOption.java
@@ -1,0 +1,14 @@
+package org.icepear.echarts.origin.chart.lines;
+
+import org.icepear.echarts.origin.util.LineStyleOption;
+import org.icepear.echarts.origin.util.SeriesLabelOption;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-lines.lineStyle
+ */
+public interface LinesStateOption {
+
+    LinesStateOption setLineStyle(LineStyleOption lineStyle);
+
+    LinesStateOption setLabel(SeriesLabelOption label);
+}

--- a/src/test/java/org/icepear/echarts/charts/lines/LinesSeriesTest.java
+++ b/src/test/java/org/icepear/echarts/charts/lines/LinesSeriesTest.java
@@ -1,0 +1,232 @@
+package org.icepear.echarts.charts.lines;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.icepear.echarts.Lines;
+import org.icepear.echarts.Option;
+import org.icepear.echarts.components.series.LineStyle;
+import org.icepear.echarts.components.series.SeriesLabel;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+/**
+ * Direct unit tests for the Lines series.
+ */
+public class LinesSeriesTest {
+
+    private static final EChartsSerializer SERIALIZER = new EChartsSerializer();
+
+    @Test
+    public void testDefaultTypeIsLines() {
+        assertEquals("lines", new LinesSeries().getType());
+    }
+
+    @Test
+    public void testLinesFactoryProducesLinesSeries() {
+        Lines chart = new Lines().addSeries(new LinesSeries()
+                .setData(new LinesDataItem[] {
+                        new LinesDataItem().setCoords(new Number[][] { { 0, 0 }, { 1, 1 } }) }));
+        Option option = chart.getOption();
+        JsonObject series = SERIALIZER.toJsonTree(option).getAsJsonObject()
+                .get("series").getAsJsonArray().get(0).getAsJsonObject();
+        assertEquals("lines", series.get("type").getAsString());
+    }
+
+    @Test
+    public void testLinesEffectAllFields() {
+        LinesEffect e = new LinesEffect()
+                .setShow(true)
+                .setPeriod(6)
+                .setDelay(100)
+                .setConstantSpeed(40)
+                .setSymbol("triangle")
+                .setSymbolSize(12)
+                .setColor("#fff")
+                .setTrailLength(0.5)
+                .setLoop(true)
+                .setRoundTrip(false);
+        JsonObject json = SERIALIZER.toJsonTree(e).getAsJsonObject();
+        assertEquals(true, json.get("show").getAsBoolean());
+        assertEquals(6, json.get("period").getAsInt());
+        assertEquals(100, json.get("delay").getAsInt());
+        assertEquals(40, json.get("constantSpeed").getAsInt());
+        assertEquals("triangle", json.get("symbol").getAsString());
+        assertEquals(12, json.get("symbolSize").getAsInt());
+        assertEquals("#fff", json.get("color").getAsString());
+        assertEquals(0.5, json.get("trailLength").getAsDouble(), 0.0);
+        assertEquals(true, json.get("loop").getAsBoolean());
+        assertEquals(false, json.get("roundTrip").getAsBoolean());
+    }
+
+    @Test
+    public void testEffectSymbolSizeArrayOverload() {
+        LinesEffect e = new LinesEffect().setSymbolSize(new Number[] { 10, 20 });
+        assertTrue(e.getSymbolSize() instanceof Number[]);
+    }
+
+    @Test
+    public void testCoordinateSystemOptions() {
+        for (String cs : new String[] { "geo", "cartesian2d", "polar" }) {
+            JsonObject json = SERIALIZER.toJsonTree(
+                    new LinesSeries().setCoordinateSystem(cs)).getAsJsonObject();
+            assertEquals(cs, json.get("coordinateSystem").getAsString());
+        }
+    }
+
+    @Test
+    public void testPolylineFlag() {
+        JsonObject json = SERIALIZER.toJsonTree(
+                new LinesSeries().setPolyline(true)).getAsJsonObject();
+        assertEquals(true, json.get("polyline").getAsBoolean());
+    }
+
+    @Test
+    public void testLargeAndLargeThreshold() {
+        JsonObject json = SERIALIZER.toJsonTree(
+                new LinesSeries().setLarge(true).setLargeThreshold(2000)).getAsJsonObject();
+        assertEquals(true, json.get("large").getAsBoolean());
+        assertEquals(2000, json.get("largeThreshold").getAsInt());
+    }
+
+    @Test
+    public void testGeoIndexAndId() {
+        JsonObject json = SERIALIZER.toJsonTree(
+                new LinesSeries().setGeoIndex(0).setGeoId("g1")).getAsJsonObject();
+        assertEquals(0, json.get("geoIndex").getAsInt());
+        assertEquals("g1", json.get("geoId").getAsString());
+    }
+
+    @Test
+    public void testCartesianAxisIndices() {
+        JsonObject json = SERIALIZER.toJsonTree(
+                new LinesSeries().setXAxisIndex(1).setYAxisIndex(2)).getAsJsonObject();
+        assertEquals(1, json.get("xAxisIndex").getAsInt());
+        assertEquals(2, json.get("yAxisIndex").getAsInt());
+    }
+
+    @Test
+    public void testLineStyleNested() {
+        LinesSeries s = new LinesSeries()
+                .setLineStyle(new LineStyle().setColor("#abc").setWidth(2).setOpacity(0.5));
+        JsonObject ls = SERIALIZER.toJsonTree(s).getAsJsonObject().get("lineStyle").getAsJsonObject();
+        assertEquals("#abc", ls.get("color").getAsString());
+        assertEquals(2, ls.get("width").getAsInt());
+        assertEquals(0.5, ls.get("opacity").getAsDouble(), 0.0);
+    }
+
+    @Test
+    public void testDataItemCoordsAndValue() {
+        LinesDataItem item = new LinesDataItem()
+                .setName("flight-1")
+                .setCoords(new Number[][] { { 0, 0 }, { 100, 100 } })
+                .setValue(50);
+        JsonObject json = SERIALIZER.toJsonTree(item).getAsJsonObject();
+        assertEquals("flight-1", json.get("name").getAsString());
+        assertEquals(2, json.get("coords").getAsJsonArray().size());
+        assertEquals(50, json.get("value").getAsInt());
+    }
+
+    @Test
+    public void testDataItemValueArrayOverload() {
+        LinesDataItem item = new LinesDataItem().setValue(new Number[] { 1, 2 });
+        JsonObject json = SERIALIZER.toJsonTree(item).getAsJsonObject();
+        assertEquals(2, json.get("value").getAsJsonArray().size());
+    }
+
+    @Test
+    public void testEmphasisFocusAndDisabled() {
+        LinesEmphasis e = new LinesEmphasis()
+                .setFocus("series")
+                .setDisabled(false)
+                .setLineStyle(new LineStyle().setWidth(4));
+        JsonObject json = SERIALIZER.toJsonTree(e).getAsJsonObject();
+        assertEquals("series", json.get("focus").getAsString());
+        assertEquals(false, json.get("disabled").getAsBoolean());
+        assertEquals(4, json.get("lineStyle").getAsJsonObject().get("width").getAsInt());
+    }
+
+    @Test
+    public void testLabelOnSeries() {
+        LinesSeries s = new LinesSeries().setLabel(new SeriesLabel().setShow(true).setFormatter("{b}"));
+        JsonObject json = SERIALIZER.toJsonTree(s).getAsJsonObject();
+        assertEquals(true, json.get("label").getAsJsonObject().get("show").getAsBoolean());
+        assertEquals("{b}", json.get("label").getAsJsonObject().get("formatter").getAsString());
+    }
+
+    @Test
+    public void testSymbolStringAndArray() {
+        LinesSeries asString = new LinesSeries().setSymbol("arrow");
+        LinesSeries asArr = new LinesSeries().setSymbol(new String[] { "circle", "arrow" });
+        assertEquals("arrow", asString.getSymbol());
+        assertNotNull(asArr.getSymbol());
+        assertTrue(asArr.getSymbol() instanceof String[]);
+    }
+
+    @Test
+    public void testSymbolSizeOverloads() {
+        LinesSeries n = new LinesSeries().setSymbolSize(15);
+        LinesSeries arr = new LinesSeries().setSymbolSize(new Number[] { 8, 16 });
+        assertEquals(15, ((Number) n.getSymbolSize()).intValue());
+        assertTrue(arr.getSymbolSize() instanceof Number[]);
+    }
+
+    @Test
+    public void testNullableFieldsAreOmitted() {
+        JsonObject json = SERIALIZER.toJsonTree(new LinesSeries()).getAsJsonObject();
+        assertEquals("lines", json.get("type").getAsString());
+        assertNull(json.get("data"));
+        assertNull(json.get("effect"));
+        assertNull(json.get("polyline"));
+        assertNull(json.get("coordinateSystem"));
+    }
+
+    @Test
+    public void testParsedJsonRoundTrips() {
+        LinesSeries s = new LinesSeries()
+                .setEffect(new LinesEffect().setShow(true).setTrailLength(0.3))
+                .setData(new LinesDataItem[] {
+                        new LinesDataItem().setCoords(new Number[][] { { 0, 0 }, { 1, 1 } }) });
+        JsonElement first = JsonParser.parseString(SERIALIZER.toJson(s));
+        JsonElement second = JsonParser.parseString(SERIALIZER.toJson(s));
+        assertEquals(first, second);
+    }
+
+    @Test
+    public void testChartChainable() {
+        Lines chart = new Lines()
+                .setTitle("Flight paths")
+                .setLegend()
+                .addSeries(new LinesSeries().setData(new LinesDataItem[] {
+                        new LinesDataItem().setCoords(new Number[][] { { 0, 0 }, { 1, 1 } }) }));
+        Option o = chart.getOption();
+        assertNotNull(o.getTitle());
+        assertNotNull(o.getLegend());
+        assertNotNull(o.getSeries());
+    }
+
+    @Test
+    public void testLinesDoesNotEmitEmptyAxisArrays() {
+        // Lines extends base Chart (not CartesianCoordChart), so xAxis/yAxis must be absent
+        // when the user hasn't configured them — important for geo coordinate usage.
+        Lines chart = new Lines().addSeries(new LinesSeries().setData(new LinesDataItem[] {
+                new LinesDataItem().setCoords(new Number[][] { { 0, 0 }, { 1, 1 } }) }));
+        JsonObject json = SERIALIZER.toJsonTree(chart.getOption()).getAsJsonObject();
+        assertNull(json.get("xAxis"));
+        assertNull(json.get("yAxis"));
+    }
+
+    @Test
+    public void testCoordsRoundTrip() {
+        Number[][] coords = { { 1, 2 }, { 3, 4 }, { 5, 6 } };
+        LinesDataItem item = new LinesDataItem().setCoords(coords);
+        assertArrayEquals(coords, item.getCoords());
+    }
+}

--- a/src/test/java/org/icepear/echarts/demo/LinesDemo.java
+++ b/src/test/java/org/icepear/echarts/demo/LinesDemo.java
@@ -1,0 +1,82 @@
+package org.icepear.echarts.demo;
+
+import java.io.FileWriter;
+import java.io.Writer;
+
+import org.icepear.echarts.Lines;
+import org.icepear.echarts.charts.lines.LinesDataItem;
+import org.icepear.echarts.charts.lines.LinesEffect;
+import org.icepear.echarts.charts.lines.LinesSeries;
+import org.icepear.echarts.components.series.LineStyle;
+import org.icepear.echarts.components.title.Title;
+import org.icepear.echarts.components.tooltip.Tooltip;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+/**
+ * Local-only demo: writes /tmp/lines-demo.html.
+ *
+ * Run: mvn test -Dtest=LinesDemo
+ * Then: open /tmp/lines-demo.html
+ */
+public class LinesDemo {
+
+    @Test
+    public void writeDemoHtml() throws Exception {
+        // 5 fictional "city" coordinates on a 2D plane (no real geo).
+        Number[] sf  = { 10, 60 };
+        Number[] la  = { 20, 30 };
+        Number[] chi = { 60, 70 };
+        Number[] ny  = { 90, 75 };
+        Number[] mia = { 88, 15 };
+
+        LinesDataItem[] data = new LinesDataItem[] {
+                new LinesDataItem().setCoords(new Number[][] { sf, ny }),
+                new LinesDataItem().setCoords(new Number[][] { la, chi }),
+                new LinesDataItem().setCoords(new Number[][] { la, mia }),
+                new LinesDataItem().setCoords(new Number[][] { chi, ny }),
+                new LinesDataItem().setCoords(new Number[][] { sf, mia })
+        };
+
+        Lines chart = new Lines()
+                .setTitle(new Title().setText("Animated Flight Paths").setLeft("center"))
+                .setTooltip(new Tooltip().setTrigger("item"))
+                .addSeries(new LinesSeries()
+                        .setName("Routes")
+                        .setCoordinateSystem("cartesian2d")
+                        .setPolyline(false)
+                        .setEffect(new LinesEffect()
+                                .setShow(true)
+                                .setSymbol("arrow")
+                                .setSymbolSize(8)
+                                .setTrailLength(0.7)
+                                .setPeriod(6))
+                        .setLineStyle(new LineStyle()
+                                .setColor("#a6c8ff")
+                                .setWidth(1)
+                                .setOpacity(0.6)
+                                .setType("solid"))
+                        .setData(data));
+
+        String optionJson = new EChartsSerializer().toJson(chart.getOption());
+
+        // Lines extends base Chart, so axes aren't auto-emitted.  For the cartesian2d demo
+        // we layer minimal axes onto the option after serialization via JS.
+        String html = "<!doctype html><html><head><meta charset='utf-8'><title>Lines Demo</title>"
+                + "<script src='https://cdnjs.cloudflare.com/ajax/libs/echarts/5.4.3/echarts.min.js'></script>"
+                + "<style>html,body,#chart{margin:0;width:100%;height:100vh;background:#0b1220}</style>"
+                + "</head><body><div id='chart'></div><script>"
+                + "const chart = echarts.init(document.getElementById('chart'),'dark');"
+                + "const opt = " + optionJson + ";"
+                + "opt.xAxis = { type: 'value', min: 0, max: 100, show: false };"
+                + "opt.yAxis = { type: 'value', min: 0, max: 100, show: false };"
+                + "chart.setOption(opt);"
+                + "window.addEventListener('resize', () => chart.resize());"
+                + "</script></body></html>";
+
+        try (Writer w = new FileWriter("/tmp/lines-demo.html")) {
+            w.write(html);
+        }
+        System.out.println("\n>>> Wrote /tmp/lines-demo.html — open it in a browser.\n");
+    }
+}

--- a/src/test/java/org/icepear/echarts/render/simple/RenderLinesByChartTest.java
+++ b/src/test/java/org/icepear/echarts/render/simple/RenderLinesByChartTest.java
@@ -1,0 +1,48 @@
+package org.icepear.echarts.render.simple;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.icepear.echarts.Chart;
+import org.icepear.echarts.Lines;
+import org.icepear.echarts.charts.lines.LinesDataItem;
+import org.icepear.echarts.charts.lines.LinesEffect;
+import org.icepear.echarts.charts.lines.LinesSeries;
+import org.icepear.echarts.render.Engine;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RenderLinesByChartTest {
+    private Chart<?, ?> chart;
+
+    @Before
+    public void constructChart() {
+        this.chart = new Lines()
+                .setTitle("Flight Paths")
+                .addSeries(new LinesSeries()
+                        .setCoordinateSystem("cartesian2d")
+                        .setEffect(new LinesEffect().setShow(true).setSymbol("arrow"))
+                        .setData(new LinesDataItem[] {
+                                new LinesDataItem().setCoords(new Number[][] { { 0, 0 }, { 50, 80 } })
+                        }));
+    }
+
+    @Test
+    public void testRenderLinesJsonOption() {
+        Engine engine = new Engine();
+        String json = engine.renderJsonOption(chart);
+        assertNotNull(json);
+        assertTrue(json.contains("\"type\":\"lines\""));
+        assertTrue(json.contains("\"effect\""));
+        assertTrue(json.contains("\"coords\""));
+    }
+
+    @Test
+    public void testRenderLinesHtml() {
+        Engine engine = new Engine();
+        String html = engine.renderHtml(chart);
+        assertNotNull(html);
+        assertTrue(html.contains("setOption"));
+        assertTrue(html.contains("\"type\":\"lines\""));
+    }
+}

--- a/src/test/java/org/icepear/echarts/simple/lines/BasicLinesTest.java
+++ b/src/test/java/org/icepear/echarts/simple/lines/BasicLinesTest.java
@@ -1,0 +1,41 @@
+package org.icepear.echarts.simple.lines;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import org.icepear.echarts.Lines;
+import org.icepear.echarts.charts.lines.LinesDataItem;
+import org.icepear.echarts.charts.lines.LinesEffect;
+import org.icepear.echarts.charts.lines.LinesSeries;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+public class BasicLinesTest {
+
+    @Test
+    public void testBasicLines() {
+        LinesDataItem[] data = new LinesDataItem[] {
+                new LinesDataItem().setCoords(new Number[][] { { 0, 0 }, { 50, 80 } }),
+                new LinesDataItem().setCoords(new Number[][] { { 50, 80 }, { 120, 30 } }),
+                new LinesDataItem().setCoords(new Number[][] { { 120, 30 }, { 200, 90 } })
+        };
+
+        Lines chart = new Lines()
+                .addSeries(new LinesSeries()
+                        .setCoordinateSystem("cartesian2d")
+                        .setPolyline(false)
+                        .setEffect(new LinesEffect().setShow(true).setSymbol("arrow").setTrailLength(0.7))
+                        .setData(data));
+
+        Reader reader = new InputStreamReader(
+                this.getClass().getResourceAsStream("/simple/lines/basic-lines.json"));
+        JsonElement expected = JsonParser.parseReader(reader);
+        JsonElement actual = new EChartsSerializer().toJsonTree(chart.getOption());
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/resources/simple/lines/basic-lines.json
+++ b/src/test/resources/simple/lines/basic-lines.json
@@ -1,0 +1,15 @@
+{
+  "series": [
+    {
+      "type": "lines",
+      "data": [
+        { "coords": [[0, 0], [50, 80]] },
+        { "coords": [[50, 80], [120, 30]] },
+        { "coords": [[120, 30], [200, 90]] }
+      ],
+      "coordinateSystem": "cartesian2d",
+      "polyline": false,
+      "effect": { "show": true, "symbol": "arrow", "trailLength": 0.7 }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds the **lines** series — draws lines/curves between coordinate pairs. The standard pick for flight paths, geo flows, and migration visualizations. Pairs naturally with `map` (PR #101) and `effectScatter` (PR #102) for the canonical "animated flows on a map" pattern.
- `Lines` extends the base `Chart` (not `CartesianCoordChart`), so empty `xAxis` / `yAxis` arrays aren't auto-emitted — important when the user is using `coordinateSystem: "geo"`. For cartesian2d usage, axes can be wired via `Option` directly.

## Public API added
- `Lines`
- `charts.lines.LinesSeries`, `LinesDataItem`, `LinesEmphasis`, `LinesEffect`
- `origin.chart.lines.LinesSeriesOption`, `LinesStateOption`, `LinesEmphasisOption`, `LinesDataItemOption`, `LinesEffectOption`

## How to use

### Cartesian (no map needed)

```java
Lines chart = new Lines()
    .setTitle("Flight paths")
    .addSeries(new LinesSeries()
        .setCoordinateSystem("cartesian2d")
        .setPolyline(false)
        .setEffect(new LinesEffect().setShow(true).setSymbol("arrow").setTrailLength(0.7))
        .setData(new LinesDataItem[] {
            new LinesDataItem().setCoords(new Number[][] { {0, 0}, {50, 80} }),
            new LinesDataItem().setCoords(new Number[][] { {50, 80}, {120, 30} })
        }));
```

### Geo (paired with the map series from PR #101)

```java
new LinesSeries()
    .setCoordinateSystem("geo")
    .setEffect(new LinesEffect().setShow(true).setSymbol("arrow").setTrailLength(0.6))
    .setLineStyle(new LineStyle().setColor("#a6c8ff").setWidth(1).setOpacity(0.6))
    .setData(/* lng/lat pairs */);
```

For a runnable visual demo with 5 "flight paths" on a dark canvas, see `src/test/java/org/icepear/echarts/demo/LinesDemo.java` — run `mvn test -Dtest=LinesDemo` then `open /tmp/lines-demo.html`.

## Tests added (25 new, all passing)
- `simple/lines/BasicLinesTest` — snapshot
- `charts/lines/LinesSeriesTest` — 21 unit tests covering every setter overload, all three coordinate systems, effect nesting, lineStyle nesting, emphasis flags, the no-empty-axis-arrays invariant, null-omission, and round-trip serialization
- `render/simple/RenderLinesByChartTest` — Engine smoke test
- `demo/LinesDemo` — opt-in HTML writer for visual inspection

## Test plan
- [x] `mvn test -Dtest=BasicLinesTest` — 1/1
- [x] `mvn test -Dtest=LinesSeriesTest` — 21/21
- [x] `mvn test -Dtest=RenderLinesByChartTest` — 2/2
- [x] `mvn test -Dtest=LinesDemo` then `open /tmp/lines-demo.html` — animated arrows render correctly
- [x] `mvn test` (full suite) — 101 tests, only the 3 pre-existing polar/float-precision failures remain

https://github.com/user-attachments/assets/7232e5a0-2b54-48b1-819b-7bf91790b2f8
