### PR TITLE
Add PictorialBar chart support

### DIFF
--- a/scripts/config/org/icepear/echarts/charts/pictorialBar/pictorial-bar-data-item.json
+++ b/scripts/config/org/icepear/echarts/charts/pictorialBar/pictorial-bar-data-item.json
@@ -1,0 +1,5 @@
+{
+  "name": "PictorialBarDataItem",
+  "type": "class",
+  "implements": ["PictorialBarDataItemOption"]
+}

--- a/scripts/config/org/icepear/echarts/charts/pictorialBar/pictorial-bar-emphasis.json
+++ b/scripts/config/org/icepear/echarts/charts/pictorialBar/pictorial-bar-emphasis.json
@@ -1,0 +1,5 @@
+{
+  "name": "PictorialBarEmphasis",
+  "type": "class",
+  "implements": ["PictorialBarEmphasisOption"]
+}

--- a/scripts/config/org/icepear/echarts/charts/pictorialBar/pictorial-bar-series.json
+++ b/scripts/config/org/icepear/echarts/charts/pictorialBar/pictorial-bar-series.json
@@ -1,0 +1,5 @@
+{
+  "name": "PictorialBarSeries",
+  "type": "class",
+  "implements": ["PictorialBarSeriesOption"]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/pictorialBar/pictorial-bar-data-item-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/pictorialBar/pictorial-bar-data-item-option.json
@@ -1,0 +1,29 @@
+{
+  "name": "PictorialBarDataItemOption",
+  "type": "interface",
+  "extends": [
+    "PictorialBarStateOption",
+    "StatesOptionMixin",
+    "DefaultOptionDataItemObject"
+  ],
+  "fields": [
+    { "name": "cursor", "types": ["String"] },
+    { "name": "symbol", "types": ["String"] },
+    { "name": "symbolSize", "types": ["Number", "Number[]", "String", "String[]"] },
+    { "name": "symbolPosition", "types": ["String"] },
+    { "name": "symbolOffset", "types": ["Number[]", "String[]"] },
+    { "name": "symbolRotate", "types": ["Number"] },
+    { "name": "symbolRepeat", "types": ["Boolean", "Number", "String"] },
+    { "name": "symbolRepeatDirection", "types": ["String"] },
+    { "name": "symbolMargin", "types": ["Number", "String"] },
+    { "name": "symbolClip", "types": ["Boolean"] },
+    { "name": "symbolBoundingData", "types": ["Number", "Number[]"] },
+    { "name": "symbolPatternSize", "types": ["Number"] },
+    { "name": "hoverAnimation", "types": ["Boolean"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-pictorialBar.data",
+    "",
+    "Each data item may override the series-level pictorial-symbol settings."
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/pictorialBar/pictorial-bar-emphasis-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/pictorialBar/pictorial-bar-emphasis-option.json
@@ -1,0 +1,15 @@
+{
+  "name": "PictorialBarEmphasisOption",
+  "type": "interface",
+  "extends": [
+    "DefaultStatesMixinEmpasis",
+    "PictorialBarStateOption",
+    "EmphasisOption"
+  ],
+  "fields": [
+    { "name": "disabled", "types": ["Boolean"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-pictorialBar.emphasis"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/pictorialBar/pictorial-bar-series-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/pictorialBar/pictorial-bar-series-option.json
@@ -1,0 +1,43 @@
+{
+  "name": "PictorialBarSeriesOption",
+  "type": "interface",
+  "extends": [
+    "BaseBarSeriesOption",
+    "PictorialBarStateOption",
+    "SeriesStackOptionMixin",
+    "SeriesEncodeOptionMixin"
+  ],
+  "fields": [
+    { "name": "type", "types": ["String"], "default": "pictorialBar" },
+    { "name": "coordinateSystem", "types": ["String"] },
+    { "name": "clip", "types": ["Boolean"] },
+    { "name": "symbol", "types": ["String"] },
+    { "name": "symbolSize", "types": ["Number", "Number[]", "String", "String[]"] },
+    { "name": "symbolPosition", "types": ["String"] },
+    { "name": "symbolOffset", "types": ["Number[]", "String[]"] },
+    { "name": "symbolRotate", "types": ["Number"] },
+    { "name": "symbolRepeat", "types": ["Boolean", "Number", "String"] },
+    { "name": "symbolRepeatDirection", "types": ["String"] },
+    { "name": "symbolMargin", "types": ["Number", "String"] },
+    { "name": "symbolClip", "types": ["Boolean"] },
+    { "name": "symbolBoundingData", "types": ["Number", "Number[]"] },
+    { "name": "symbolPatternSize", "types": ["Number"] },
+    { "name": "hoverAnimation", "types": ["Boolean"] },
+    {
+      "name": "data",
+      "types": [
+        "String[]",
+        "String[][]",
+        "Number[]",
+        "Number[][]",
+        "Date[]",
+        "Date[][]",
+        "PictorialBarDataItemOption[]"
+      ]
+    },
+    { "name": "emphasis", "types": ["PictorialBarEmphasisOption"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-pictorialBar"
+  ]
+}

--- a/scripts/config/org/icepear/echarts/origin/chart/pictorialBar/pictorial-bar-state-option.json
+++ b/scripts/config/org/icepear/echarts/origin/chart/pictorialBar/pictorial-bar-state-option.json
@@ -1,0 +1,13 @@
+{
+  "name": "PictorialBarStateOption",
+  "type": "interface",
+  "extends": [],
+  "fields": [
+    { "name": "itemStyle", "types": ["BarItemStyleOption"] },
+    { "name": "label", "types": ["BarLabelOption"] }
+  ],
+  "comments": [
+    "https://echarts.apache.org/en/option.html#series-pictorialBar.itemStyle",
+    "https://echarts.apache.org/en/option.html#series-pictorialBar.label"
+  ]
+}

--- a/src/main/java/org/icepear/echarts/PictorialBar.java
+++ b/src/main/java/org/icepear/echarts/PictorialBar.java
@@ -1,0 +1,19 @@
+package org.icepear.echarts;
+
+import java.io.Serializable;
+
+import org.icepear.echarts.charts.pictorialBar.PictorialBarSeries;
+
+public class PictorialBar extends CartesianCoordChart<PictorialBar, PictorialBarSeries> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public PictorialBar() {
+        super(PictorialBar.class, PictorialBarSeries.class);
+    }
+
+    @Override
+    protected PictorialBarSeries createSeries() {
+        return new PictorialBarSeries().setType("pictorialBar");
+    }
+}

--- a/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarDataItem.java
@@ -17,6 +17,16 @@ public class PictorialBarDataItem implements PictorialBarDataItemOption, Seriali
 
     private static final long serialVersionUID = 1L;
 
+    private BarItemStyleOption itemStyle;
+
+    private BarLabelOption label;
+
+    private Object emphasis;
+
+    private Object select;
+
+    private Object blur;
+
     @Setter(AccessLevel.NONE)
     private Object id;
 
@@ -92,16 +102,6 @@ public class PictorialBarDataItem implements PictorialBarDataItemOption, Seriali
     }
 
     private String cursor;
-
-    private BarItemStyleOption itemStyle;
-
-    private BarLabelOption label;
-
-    private Object emphasis;
-
-    private Object select;
-
-    private Object blur;
 
     private String symbol;
 

--- a/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarDataItem.java
+++ b/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarDataItem.java
@@ -1,0 +1,199 @@
+package org.icepear.echarts.charts.pictorialBar;
+
+import java.io.Serializable;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.bar.BarItemStyleOption;
+import org.icepear.echarts.origin.chart.bar.BarLabelOption;
+import org.icepear.echarts.origin.chart.pictorialBar.PictorialBarDataItemOption;
+
+@Accessors(chain = true)
+@Data
+public class PictorialBarDataItem implements PictorialBarDataItemOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Setter(AccessLevel.NONE)
+    private Object id;
+
+    public PictorialBarDataItem setId(Number id) {
+        this.id = id;
+        return this;
+    }
+
+    public PictorialBarDataItem setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object name;
+
+    public PictorialBarDataItem setName(Number name) {
+        this.name = name;
+        return this;
+    }
+
+    public PictorialBarDataItem setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object groupId;
+
+    public PictorialBarDataItem setGroupId(Number groupId) {
+        this.groupId = groupId;
+        return this;
+    }
+
+    public PictorialBarDataItem setGroupId(String groupId) {
+        this.groupId = groupId;
+        return this;
+    }
+
+    private Boolean selected;
+
+    @Setter(AccessLevel.NONE)
+    private Object value;
+
+    public PictorialBarDataItem setValue(Number value) {
+        this.value = value;
+        return this;
+    }
+
+    public PictorialBarDataItem setValue(Number[] value) {
+        this.value = value;
+        return this;
+    }
+
+    public PictorialBarDataItem setValue(Object value) {
+        this.value = value;
+        return this;
+    }
+
+    public PictorialBarDataItem setValue(Object[] value) {
+        this.value = value;
+        return this;
+    }
+
+    public PictorialBarDataItem setValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+    public PictorialBarDataItem setValue(String[] value) {
+        this.value = value;
+        return this;
+    }
+
+    private String cursor;
+
+    private BarItemStyleOption itemStyle;
+
+    private BarLabelOption label;
+
+    private Object emphasis;
+
+    private Object select;
+
+    private Object blur;
+
+    private String symbol;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolSize;
+
+    public PictorialBarDataItem setSymbolSize(Number symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    public PictorialBarDataItem setSymbolSize(Number[] symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    public PictorialBarDataItem setSymbolSize(String symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    public PictorialBarDataItem setSymbolSize(String[] symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    private String symbolPosition;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolOffset;
+
+    public PictorialBarDataItem setSymbolOffset(Number[] symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    public PictorialBarDataItem setSymbolOffset(String[] symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    private Number symbolRotate;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolRepeat;
+
+    public PictorialBarDataItem setSymbolRepeat(Boolean symbolRepeat) {
+        this.symbolRepeat = symbolRepeat;
+        return this;
+    }
+
+    public PictorialBarDataItem setSymbolRepeat(Number symbolRepeat) {
+        this.symbolRepeat = symbolRepeat;
+        return this;
+    }
+
+    public PictorialBarDataItem setSymbolRepeat(String symbolRepeat) {
+        this.symbolRepeat = symbolRepeat;
+        return this;
+    }
+
+    private String symbolRepeatDirection;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolMargin;
+
+    public PictorialBarDataItem setSymbolMargin(Number symbolMargin) {
+        this.symbolMargin = symbolMargin;
+        return this;
+    }
+
+    public PictorialBarDataItem setSymbolMargin(String symbolMargin) {
+        this.symbolMargin = symbolMargin;
+        return this;
+    }
+
+    private Boolean symbolClip;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolBoundingData;
+
+    public PictorialBarDataItem setSymbolBoundingData(Number symbolBoundingData) {
+        this.symbolBoundingData = symbolBoundingData;
+        return this;
+    }
+
+    public PictorialBarDataItem setSymbolBoundingData(Number[] symbolBoundingData) {
+        this.symbolBoundingData = symbolBoundingData;
+        return this;
+    }
+
+    private Number symbolPatternSize;
+
+    private Boolean hoverAnimation;
+}

--- a/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarEmphasis.java
@@ -15,8 +15,6 @@ public class PictorialBarEmphasis implements PictorialBarEmphasisOption, Seriali
 
     private static final long serialVersionUID = 1L;
 
-    private Boolean disabled;
-
     private String focus;
 
     private BarItemStyleOption itemStyle;
@@ -24,4 +22,6 @@ public class PictorialBarEmphasis implements PictorialBarEmphasisOption, Seriali
     private BarLabelOption label;
 
     private Object blurScope;
+
+    private Boolean disabled;
 }

--- a/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarEmphasis.java
+++ b/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarEmphasis.java
@@ -1,0 +1,27 @@
+package org.icepear.echarts.charts.pictorialBar;
+
+import java.io.Serializable;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.bar.BarItemStyleOption;
+import org.icepear.echarts.origin.chart.bar.BarLabelOption;
+import org.icepear.echarts.origin.chart.pictorialBar.PictorialBarEmphasisOption;
+
+@Accessors(chain = true)
+@Data
+public class PictorialBarEmphasis implements PictorialBarEmphasisOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Boolean disabled;
+
+    private String focus;
+
+    private BarItemStyleOption itemStyle;
+
+    private BarLabelOption label;
+
+    private Object blurScope;
+}

--- a/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarSeries.java
@@ -138,12 +138,12 @@ public class PictorialBarSeries implements PictorialBarSeriesOption, Serializabl
     @Setter(AccessLevel.NONE)
     private Object emphasis;
 
-    public PictorialBarSeries setEmphasis(PictorialBarEmphasisOption emphasis) {
+    public PictorialBarSeries setEmphasis(Object emphasis) {
         this.emphasis = emphasis;
         return this;
     }
 
-    public PictorialBarSeries setEmphasis(Object emphasis) {
+    public PictorialBarSeries setEmphasis(PictorialBarEmphasisOption emphasis) {
         this.emphasis = emphasis;
         return this;
     }
@@ -182,11 +182,6 @@ public class PictorialBarSeries implements PictorialBarSeriesOption, Serializabl
     @Setter(AccessLevel.NONE)
     private Object data;
 
-    public PictorialBarSeries setData(PictorialBarDataItemOption[] data) {
-        this.data = data;
-        return this;
-    }
-
     public PictorialBarSeries setData(Number[] data) {
         this.data = data;
         return this;
@@ -208,6 +203,11 @@ public class PictorialBarSeries implements PictorialBarSeriesOption, Serializabl
     }
 
     public PictorialBarSeries setData(Object[][] data) {
+        this.data = data;
+        return this;
+    }
+
+    public PictorialBarSeries setData(PictorialBarDataItemOption[] data) {
         this.data = data;
         return this;
     }

--- a/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarSeries.java
+++ b/src/main/java/org/icepear/echarts/charts/pictorialBar/PictorialBarSeries.java
@@ -1,0 +1,482 @@
+package org.icepear.echarts.charts.pictorialBar;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.icepear.echarts.origin.chart.bar.BarItemStyleOption;
+import org.icepear.echarts.origin.chart.bar.BarLabelOption;
+import org.icepear.echarts.origin.chart.pictorialBar.PictorialBarDataItemOption;
+import org.icepear.echarts.origin.chart.pictorialBar.PictorialBarEmphasisOption;
+import org.icepear.echarts.origin.chart.pictorialBar.PictorialBarSeriesOption;
+import org.icepear.echarts.origin.component.marker.MarkAreaOption;
+import org.icepear.echarts.origin.component.marker.MarkLineOption;
+import org.icepear.echarts.origin.component.marker.MarkPointOption;
+import org.icepear.echarts.origin.util.LabelLayoutOption;
+import org.icepear.echarts.origin.util.LabelLineOption;
+import org.icepear.echarts.origin.util.OptionEncode;
+
+@Accessors(chain = true)
+@Data
+public class PictorialBarSeries implements PictorialBarSeriesOption, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String mainType;
+
+    private String type = "pictorialBar";
+
+    @Setter(AccessLevel.NONE)
+    private Object id;
+
+    public PictorialBarSeries setId(Number id) {
+        this.id = id;
+        return this;
+    }
+
+    public PictorialBarSeries setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object name;
+
+    public PictorialBarSeries setName(Number name) {
+        this.name = name;
+        return this;
+    }
+
+    public PictorialBarSeries setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    private Number z;
+
+    private Number zlevel;
+
+    private Boolean animation;
+
+    private Number animationThreshold;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDuration;
+
+    public PictorialBarSeries setAnimationDuration(Number animationDuration) {
+        this.animationDuration = animationDuration;
+        return this;
+    }
+
+    public PictorialBarSeries setAnimationDuration(Object animationDuration) {
+        this.animationDuration = animationDuration;
+        return this;
+    }
+
+    private Object animationEasing;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDelay;
+
+    public PictorialBarSeries setAnimationDelay(Number animationDelay) {
+        this.animationDelay = animationDelay;
+        return this;
+    }
+
+    public PictorialBarSeries setAnimationDelay(Object animationDelay) {
+        this.animationDelay = animationDelay;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDurationUpdate;
+
+    public PictorialBarSeries setAnimationDurationUpdate(Number animationDurationUpdate) {
+        this.animationDurationUpdate = animationDurationUpdate;
+        return this;
+    }
+
+    public PictorialBarSeries setAnimationDurationUpdate(Object animationDurationUpdate) {
+        this.animationDurationUpdate = animationDurationUpdate;
+        return this;
+    }
+
+    private Object animationEasingUpdate;
+
+    @Setter(AccessLevel.NONE)
+    private Object animationDelayUpdate;
+
+    public PictorialBarSeries setAnimationDelayUpdate(Number animationDelayUpdate) {
+        this.animationDelayUpdate = animationDelayUpdate;
+        return this;
+    }
+
+    public PictorialBarSeries setAnimationDelayUpdate(Object animationDelayUpdate) {
+        this.animationDelayUpdate = animationDelayUpdate;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object color;
+
+    public PictorialBarSeries setColor(String color) {
+        this.color = color;
+        return this;
+    }
+
+    public PictorialBarSeries setColor(String[] color) {
+        this.color = color;
+        return this;
+    }
+
+    private String[][] colorLayer;
+
+    @Setter(AccessLevel.NONE)
+    private Object emphasis;
+
+    public PictorialBarSeries setEmphasis(PictorialBarEmphasisOption emphasis) {
+        this.emphasis = emphasis;
+        return this;
+    }
+
+    public PictorialBarSeries setEmphasis(Object emphasis) {
+        this.emphasis = emphasis;
+        return this;
+    }
+
+    private Object select;
+
+    private Object blur;
+
+    private MarkAreaOption markArea;
+
+    private MarkLineOption markLine;
+
+    private MarkPointOption markPoint;
+
+    private Object tooltip;
+
+    private Boolean silent;
+
+    private String blendMode;
+
+    private String cursor;
+
+    @Setter(AccessLevel.NONE)
+    private Object dataGroupId;
+
+    public PictorialBarSeries setDataGroupId(Number dataGroupId) {
+        this.dataGroupId = dataGroupId;
+        return this;
+    }
+
+    public PictorialBarSeries setDataGroupId(String dataGroupId) {
+        this.dataGroupId = dataGroupId;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object data;
+
+    public PictorialBarSeries setData(PictorialBarDataItemOption[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public PictorialBarSeries setData(Number[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public PictorialBarSeries setData(Number[][] data) {
+        this.data = data;
+        return this;
+    }
+
+    public PictorialBarSeries setData(Object data) {
+        this.data = data;
+        return this;
+    }
+
+    public PictorialBarSeries setData(Object[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public PictorialBarSeries setData(Object[][] data) {
+        this.data = data;
+        return this;
+    }
+
+    public PictorialBarSeries setData(String[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public PictorialBarSeries setData(String[][] data) {
+        this.data = data;
+        return this;
+    }
+
+    private String colorBy;
+
+    private Boolean legendHoverLink;
+
+    @Setter(AccessLevel.NONE)
+    private Object progressive;
+
+    public PictorialBarSeries setProgressive(Boolean progressive) {
+        this.progressive = progressive;
+        return this;
+    }
+
+    public PictorialBarSeries setProgressive(Number progressive) {
+        this.progressive = progressive;
+        return this;
+    }
+
+    private Number progressiveThreshold;
+
+    private String progressiveChunkMode;
+
+    private String coordinateSystem;
+
+    private Number hoverLayerThreshold;
+
+    @Setter(AccessLevel.NONE)
+    private Object seriesLayoutBy;
+
+    public PictorialBarSeries setSeriesLayoutBy(Object seriesLayoutBy) {
+        this.seriesLayoutBy = seriesLayoutBy;
+        return this;
+    }
+
+    public PictorialBarSeries setSeriesLayoutBy(String seriesLayoutBy) {
+        this.seriesLayoutBy = seriesLayoutBy;
+        return this;
+    }
+
+    private LabelLineOption labelLine;
+
+    private LabelLayoutOption labelLayout;
+
+    private Object stateAnimation;
+
+    @Setter(AccessLevel.NONE)
+    private Object universalTransition;
+
+    public PictorialBarSeries setUniversalTransition(Boolean universalTransition) {
+        this.universalTransition = universalTransition;
+        return this;
+    }
+
+    public PictorialBarSeries setUniversalTransition(Object universalTransition) {
+        this.universalTransition = universalTransition;
+        return this;
+    }
+
+    private Map<String, Boolean> selectedMap;
+
+    @Setter(AccessLevel.NONE)
+    private Object selectedMode;
+
+    public PictorialBarSeries setSelectedMode(Boolean selectedMode) {
+        this.selectedMode = selectedMode;
+        return this;
+    }
+
+    public PictorialBarSeries setSelectedMode(String selectedMode) {
+        this.selectedMode = selectedMode;
+        return this;
+    }
+
+    private Number xAxisIndex;
+
+    private Number yAxisIndex;
+
+    private String xAxisId;
+
+    private String yAxisId;
+
+    private Number polarIndex;
+
+    private String polarId;
+
+    private Number barMinHeight;
+
+    private Number barMinAngle;
+
+    private Number barMaxWidth;
+
+    private Number barMinWidth;
+
+    @Setter(AccessLevel.NONE)
+    private Object barWidth;
+
+    public PictorialBarSeries setBarWidth(Number barWidth) {
+        this.barWidth = barWidth;
+        return this;
+    }
+
+    public PictorialBarSeries setBarWidth(String barWidth) {
+        this.barWidth = barWidth;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object barGap;
+
+    public PictorialBarSeries setBarGap(Number barGap) {
+        this.barGap = barGap;
+        return this;
+    }
+
+    public PictorialBarSeries setBarGap(String barGap) {
+        this.barGap = barGap;
+        return this;
+    }
+
+    @Setter(AccessLevel.NONE)
+    private Object barCategoryGap;
+
+    public PictorialBarSeries setBarCategoryGap(Number barCategoryGap) {
+        this.barCategoryGap = barCategoryGap;
+        return this;
+    }
+
+    public PictorialBarSeries setBarCategoryGap(String barCategoryGap) {
+        this.barCategoryGap = barCategoryGap;
+        return this;
+    }
+
+    private Boolean large;
+
+    private Number largeThreshold;
+
+    private BarItemStyleOption itemStyle;
+
+    private BarLabelOption label;
+
+    private String stack;
+
+    private Number datasetIndex;
+
+    @Setter(AccessLevel.NONE)
+    private Object datasetId;
+
+    public PictorialBarSeries setDatasetId(Number datasetId) {
+        this.datasetId = datasetId;
+        return this;
+    }
+
+    public PictorialBarSeries setDatasetId(String datasetId) {
+        this.datasetId = datasetId;
+        return this;
+    }
+
+    private Object sourceHeader;
+
+    private Object[] dimensions;
+
+    private OptionEncode encode;
+
+    private Boolean clip;
+
+    private String symbol;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolSize;
+
+    public PictorialBarSeries setSymbolSize(Number symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    public PictorialBarSeries setSymbolSize(Number[] symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    public PictorialBarSeries setSymbolSize(String symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    public PictorialBarSeries setSymbolSize(String[] symbolSize) {
+        this.symbolSize = symbolSize;
+        return this;
+    }
+
+    private String symbolPosition;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolOffset;
+
+    public PictorialBarSeries setSymbolOffset(Number[] symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    public PictorialBarSeries setSymbolOffset(String[] symbolOffset) {
+        this.symbolOffset = symbolOffset;
+        return this;
+    }
+
+    private Number symbolRotate;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolRepeat;
+
+    public PictorialBarSeries setSymbolRepeat(Boolean symbolRepeat) {
+        this.symbolRepeat = symbolRepeat;
+        return this;
+    }
+
+    public PictorialBarSeries setSymbolRepeat(Number symbolRepeat) {
+        this.symbolRepeat = symbolRepeat;
+        return this;
+    }
+
+    public PictorialBarSeries setSymbolRepeat(String symbolRepeat) {
+        this.symbolRepeat = symbolRepeat;
+        return this;
+    }
+
+    private String symbolRepeatDirection;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolMargin;
+
+    public PictorialBarSeries setSymbolMargin(Number symbolMargin) {
+        this.symbolMargin = symbolMargin;
+        return this;
+    }
+
+    public PictorialBarSeries setSymbolMargin(String symbolMargin) {
+        this.symbolMargin = symbolMargin;
+        return this;
+    }
+
+    private Boolean symbolClip;
+
+    @Setter(AccessLevel.NONE)
+    private Object symbolBoundingData;
+
+    public PictorialBarSeries setSymbolBoundingData(Number symbolBoundingData) {
+        this.symbolBoundingData = symbolBoundingData;
+        return this;
+    }
+
+    public PictorialBarSeries setSymbolBoundingData(Number[] symbolBoundingData) {
+        this.symbolBoundingData = symbolBoundingData;
+        return this;
+    }
+
+    private Number symbolPatternSize;
+
+    private Boolean hoverAnimation;
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarDataItemOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarDataItemOption.java
@@ -5,7 +5,7 @@ import org.icepear.echarts.origin.util.StatesOptionMixin;
 
 /**
  * https://echarts.apache.org/en/option.html#series-pictorialBar.data
- *
+ * 
  * Each data item may override the series-level pictorial-symbol settings.
  */
 public interface PictorialBarDataItemOption extends PictorialBarStateOption, StatesOptionMixin, DefaultOptionDataItemObject {

--- a/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarDataItemOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarDataItemOption.java
@@ -1,0 +1,54 @@
+package org.icepear.echarts.origin.chart.pictorialBar;
+
+import org.icepear.echarts.origin.util.DefaultOptionDataItemObject;
+import org.icepear.echarts.origin.util.StatesOptionMixin;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-pictorialBar.data
+ *
+ * Each data item may override the series-level pictorial-symbol settings.
+ */
+public interface PictorialBarDataItemOption extends PictorialBarStateOption, StatesOptionMixin, DefaultOptionDataItemObject {
+
+    PictorialBarDataItemOption setCursor(String cursor);
+
+    PictorialBarDataItemOption setSymbol(String symbol);
+
+    PictorialBarDataItemOption setSymbolSize(Number symbolSize);
+
+    PictorialBarDataItemOption setSymbolSize(Number[] symbolSize);
+
+    PictorialBarDataItemOption setSymbolSize(String symbolSize);
+
+    PictorialBarDataItemOption setSymbolSize(String[] symbolSize);
+
+    PictorialBarDataItemOption setSymbolPosition(String symbolPosition);
+
+    PictorialBarDataItemOption setSymbolOffset(Number[] symbolOffset);
+
+    PictorialBarDataItemOption setSymbolOffset(String[] symbolOffset);
+
+    PictorialBarDataItemOption setSymbolRotate(Number symbolRotate);
+
+    PictorialBarDataItemOption setSymbolRepeat(Boolean symbolRepeat);
+
+    PictorialBarDataItemOption setSymbolRepeat(Number symbolRepeat);
+
+    PictorialBarDataItemOption setSymbolRepeat(String symbolRepeat);
+
+    PictorialBarDataItemOption setSymbolRepeatDirection(String symbolRepeatDirection);
+
+    PictorialBarDataItemOption setSymbolMargin(Number symbolMargin);
+
+    PictorialBarDataItemOption setSymbolMargin(String symbolMargin);
+
+    PictorialBarDataItemOption setSymbolClip(Boolean symbolClip);
+
+    PictorialBarDataItemOption setSymbolBoundingData(Number symbolBoundingData);
+
+    PictorialBarDataItemOption setSymbolBoundingData(Number[] symbolBoundingData);
+
+    PictorialBarDataItemOption setSymbolPatternSize(Number symbolPatternSize);
+
+    PictorialBarDataItemOption setHoverAnimation(Boolean hoverAnimation);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarEmphasisOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarEmphasisOption.java
@@ -1,0 +1,12 @@
+package org.icepear.echarts.origin.chart.pictorialBar;
+
+import org.icepear.echarts.origin.util.DefaultStatesMixinEmpasis;
+import org.icepear.echarts.origin.util.EmphasisOption;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-pictorialBar.emphasis
+ */
+public interface PictorialBarEmphasisOption extends DefaultStatesMixinEmpasis, PictorialBarStateOption, EmphasisOption {
+
+    PictorialBarEmphasisOption setDisabled(Boolean disabled);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarSeriesOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarSeriesOption.java
@@ -1,0 +1,74 @@
+package org.icepear.echarts.origin.chart.pictorialBar;
+
+import org.icepear.echarts.origin.chart.bar.BaseBarSeriesOption;
+import org.icepear.echarts.origin.util.SeriesEncodeOptionMixin;
+import org.icepear.echarts.origin.util.SeriesStackOptionMixin;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-pictorialBar
+ */
+public interface PictorialBarSeriesOption
+        extends BaseBarSeriesOption, PictorialBarStateOption, SeriesStackOptionMixin, SeriesEncodeOptionMixin {
+
+    PictorialBarSeriesOption setType(String type);
+
+    PictorialBarSeriesOption setCoordinateSystem(String coordinateSystem);
+
+    PictorialBarSeriesOption setClip(Boolean clip);
+
+    PictorialBarSeriesOption setSymbol(String symbol);
+
+    PictorialBarSeriesOption setSymbolSize(Number symbolSize);
+
+    PictorialBarSeriesOption setSymbolSize(Number[] symbolSize);
+
+    PictorialBarSeriesOption setSymbolSize(String symbolSize);
+
+    PictorialBarSeriesOption setSymbolSize(String[] symbolSize);
+
+    PictorialBarSeriesOption setSymbolPosition(String symbolPosition);
+
+    PictorialBarSeriesOption setSymbolOffset(Number[] symbolOffset);
+
+    PictorialBarSeriesOption setSymbolOffset(String[] symbolOffset);
+
+    PictorialBarSeriesOption setSymbolRotate(Number symbolRotate);
+
+    PictorialBarSeriesOption setSymbolRepeat(Boolean symbolRepeat);
+
+    PictorialBarSeriesOption setSymbolRepeat(Number symbolRepeat);
+
+    PictorialBarSeriesOption setSymbolRepeat(String symbolRepeat);
+
+    PictorialBarSeriesOption setSymbolRepeatDirection(String symbolRepeatDirection);
+
+    PictorialBarSeriesOption setSymbolMargin(Number symbolMargin);
+
+    PictorialBarSeriesOption setSymbolMargin(String symbolMargin);
+
+    PictorialBarSeriesOption setSymbolClip(Boolean symbolClip);
+
+    PictorialBarSeriesOption setSymbolBoundingData(Number symbolBoundingData);
+
+    PictorialBarSeriesOption setSymbolBoundingData(Number[] symbolBoundingData);
+
+    PictorialBarSeriesOption setSymbolPatternSize(Number symbolPatternSize);
+
+    PictorialBarSeriesOption setHoverAnimation(Boolean hoverAnimation);
+
+    PictorialBarSeriesOption setData(PictorialBarDataItemOption[] data);
+
+    PictorialBarSeriesOption setData(Number[] data);
+
+    PictorialBarSeriesOption setData(Number[][] data);
+
+    PictorialBarSeriesOption setData(Object[] data);
+
+    PictorialBarSeriesOption setData(Object[][] data);
+
+    PictorialBarSeriesOption setData(String[] data);
+
+    PictorialBarSeriesOption setData(String[][] data);
+
+    PictorialBarSeriesOption setEmphasis(PictorialBarEmphasisOption emphasis);
+}

--- a/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarSeriesOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarSeriesOption.java
@@ -56,8 +56,6 @@ public interface PictorialBarSeriesOption
 
     PictorialBarSeriesOption setHoverAnimation(Boolean hoverAnimation);
 
-    PictorialBarSeriesOption setData(PictorialBarDataItemOption[] data);
-
     PictorialBarSeriesOption setData(Number[] data);
 
     PictorialBarSeriesOption setData(Number[][] data);
@@ -65,6 +63,8 @@ public interface PictorialBarSeriesOption
     PictorialBarSeriesOption setData(Object[] data);
 
     PictorialBarSeriesOption setData(Object[][] data);
+
+    PictorialBarSeriesOption setData(PictorialBarDataItemOption[] data);
 
     PictorialBarSeriesOption setData(String[] data);
 

--- a/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarStateOption.java
+++ b/src/main/java/org/icepear/echarts/origin/chart/pictorialBar/PictorialBarStateOption.java
@@ -1,0 +1,15 @@
+package org.icepear.echarts.origin.chart.pictorialBar;
+
+import org.icepear.echarts.origin.chart.bar.BarItemStyleOption;
+import org.icepear.echarts.origin.chart.bar.BarLabelOption;
+
+/**
+ * https://echarts.apache.org/en/option.html#series-pictorialBar.itemStyle
+ * https://echarts.apache.org/en/option.html#series-pictorialBar.label
+ */
+public interface PictorialBarStateOption {
+
+    PictorialBarStateOption setItemStyle(BarItemStyleOption itemStyle);
+
+    PictorialBarStateOption setLabel(BarLabelOption label);
+}

--- a/src/test/java/org/icepear/echarts/charts/pictorialBar/PictorialBarSeriesTest.java
+++ b/src/test/java/org/icepear/echarts/charts/pictorialBar/PictorialBarSeriesTest.java
@@ -1,0 +1,249 @@
+package org.icepear.echarts.charts.pictorialBar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.icepear.echarts.Option;
+import org.icepear.echarts.PictorialBar;
+import org.icepear.echarts.charts.bar.BarItemStyle;
+import org.icepear.echarts.charts.bar.BarLabel;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+/**
+ * Direct unit tests for PictorialBar.
+ */
+public class PictorialBarSeriesTest {
+
+    private static final EChartsSerializer SERIALIZER = new EChartsSerializer();
+
+    @Test
+    public void testDefaultTypeIsPictorialBar() {
+        assertEquals("pictorialBar", new PictorialBarSeries().getType());
+    }
+
+    @Test
+    public void testFactoryProducesPictorialBarSeries() {
+        PictorialBar chart = new PictorialBar()
+                .addXAxis(new String[] { "A", "B" }).addYAxis()
+                .addSeries(new Number[] { 1, 2 });
+        Option option = chart.getOption();
+        JsonObject series = SERIALIZER.toJsonTree(option).getAsJsonObject()
+                .get("series").getAsJsonArray().get(0).getAsJsonObject();
+        assertEquals("pictorialBar", series.get("type").getAsString());
+    }
+
+    @Test
+    public void testSymbolField() {
+        JsonObject json = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setSymbol("path://M0,0L10,0L5,10z")).getAsJsonObject();
+        assertEquals("path://M0,0L10,0L5,10z", json.get("symbol").getAsString());
+    }
+
+    @Test
+    public void testSymbolSizeAllOverloads() {
+        assertEquals(20, ((Number) new PictorialBarSeries().setSymbolSize(20).getSymbolSize()).intValue());
+        assertTrue(new PictorialBarSeries().setSymbolSize(new Number[] { 10, 20 })
+                .getSymbolSize() instanceof Number[]);
+        assertEquals("50%", new PictorialBarSeries().setSymbolSize("50%").getSymbolSize());
+        assertTrue(new PictorialBarSeries().setSymbolSize(new String[] { "50%", "100%" })
+                .getSymbolSize() instanceof String[]);
+    }
+
+    @Test
+    public void testSymbolPosition() {
+        for (String pos : new String[] { "start", "center", "end" }) {
+            JsonObject json = SERIALIZER.toJsonTree(
+                    new PictorialBarSeries().setSymbolPosition(pos)).getAsJsonObject();
+            assertEquals(pos, json.get("symbolPosition").getAsString());
+        }
+    }
+
+    @Test
+    public void testSymbolOffsetOverloads() {
+        PictorialBarSeries n = new PictorialBarSeries().setSymbolOffset(new Number[] { 5, -5 });
+        PictorialBarSeries s = new PictorialBarSeries().setSymbolOffset(new String[] { "0%", "50%" });
+        assertNotNull(n.getSymbolOffset());
+        assertNotNull(s.getSymbolOffset());
+    }
+
+    @Test
+    public void testSymbolRotate() {
+        JsonObject json = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setSymbolRotate(45)).getAsJsonObject();
+        assertEquals(45, json.get("symbolRotate").getAsInt());
+    }
+
+    @Test
+    public void testSymbolRepeatBooleanNumberAndString() {
+        JsonObject jb = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setSymbolRepeat(true)).getAsJsonObject();
+        assertEquals(true, jb.get("symbolRepeat").getAsBoolean());
+
+        JsonObject jn = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setSymbolRepeat(5)).getAsJsonObject();
+        assertEquals(5, jn.get("symbolRepeat").getAsInt());
+
+        JsonObject js = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setSymbolRepeat("fixed")).getAsJsonObject();
+        assertEquals("fixed", js.get("symbolRepeat").getAsString());
+    }
+
+    @Test
+    public void testSymbolRepeatDirection() {
+        JsonObject json = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setSymbolRepeatDirection("end")).getAsJsonObject();
+        assertEquals("end", json.get("symbolRepeatDirection").getAsString());
+    }
+
+    @Test
+    public void testSymbolMarginNumberAndString() {
+        JsonObject jn = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setSymbolMargin(2)).getAsJsonObject();
+        assertEquals(2, jn.get("symbolMargin").getAsInt());
+
+        JsonObject js = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setSymbolMargin("10%")).getAsJsonObject();
+        assertEquals("10%", js.get("symbolMargin").getAsString());
+    }
+
+    @Test
+    public void testSymbolClipAndPatternSize() {
+        JsonObject json = SERIALIZER.toJsonTree(new PictorialBarSeries()
+                .setSymbolClip(true).setSymbolPatternSize(400)).getAsJsonObject();
+        assertEquals(true, json.get("symbolClip").getAsBoolean());
+        assertEquals(400, json.get("symbolPatternSize").getAsInt());
+    }
+
+    @Test
+    public void testSymbolBoundingDataNumberAndArray() {
+        JsonObject jn = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setSymbolBoundingData(100)).getAsJsonObject();
+        assertEquals(100, jn.get("symbolBoundingData").getAsInt());
+
+        JsonObject jarr = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setSymbolBoundingData(new Number[] { 0, 100 })).getAsJsonObject();
+        assertEquals(2, jarr.get("symbolBoundingData").getAsJsonArray().size());
+    }
+
+    @Test
+    public void testHoverAnimationFlag() {
+        JsonObject json = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setHoverAnimation(false)).getAsJsonObject();
+        assertEquals(false, json.get("hoverAnimation").getAsBoolean());
+    }
+
+    @Test
+    public void testBarLayoutFieldsCarryThrough() {
+        PictorialBarSeries s = new PictorialBarSeries()
+                .setBarWidth("60%")
+                .setBarGap(0)
+                .setBarCategoryGap("20%")
+                .setBarMaxWidth(60)
+                .setBarMinHeight(2);
+        JsonObject json = SERIALIZER.toJsonTree(s).getAsJsonObject();
+        assertEquals("60%", json.get("barWidth").getAsString());
+        assertEquals(0, json.get("barGap").getAsInt());
+        assertEquals("20%", json.get("barCategoryGap").getAsString());
+        assertEquals(60, json.get("barMaxWidth").getAsInt());
+        assertEquals(2, json.get("barMinHeight").getAsInt());
+    }
+
+    @Test
+    public void testItemStyleAndLabelNested() {
+        PictorialBarSeries s = new PictorialBarSeries()
+                .setItemStyle(new BarItemStyle().setColor("#abc").setOpacity(0.8))
+                .setLabel(new BarLabel().setShow(true).setPosition("top"));
+        JsonObject json = SERIALIZER.toJsonTree(s).getAsJsonObject();
+        assertEquals("#abc", json.get("itemStyle").getAsJsonObject().get("color").getAsString());
+        assertEquals(true, json.get("label").getAsJsonObject().get("show").getAsBoolean());
+    }
+
+    @Test
+    public void testEmphasisFocusAndDisabled() {
+        PictorialBarEmphasis e = new PictorialBarEmphasis()
+                .setFocus("series")
+                .setDisabled(false);
+        JsonObject json = SERIALIZER.toJsonTree(e).getAsJsonObject();
+        assertEquals("series", json.get("focus").getAsString());
+        assertEquals(false, json.get("disabled").getAsBoolean());
+    }
+
+    @Test
+    public void testDataItemPerPointSymbolOverride() {
+        PictorialBarDataItem item = new PictorialBarDataItem()
+                .setName("p1")
+                .setValue(50)
+                .setSymbol("rect")
+                .setSymbolSize(new Number[] { 12, 12 })
+                .setSymbolPosition("center")
+                .setSymbolRepeat(true)
+                .setSymbolRepeatDirection("start")
+                .setSymbolMargin(2)
+                .setSymbolClip(false)
+                .setSymbolPatternSize(50)
+                .setSymbolRotate(15);
+        JsonObject json = SERIALIZER.toJsonTree(item).getAsJsonObject();
+        assertEquals("rect", json.get("symbol").getAsString());
+        assertEquals("center", json.get("symbolPosition").getAsString());
+        assertEquals(true, json.get("symbolRepeat").getAsBoolean());
+        assertEquals(15, json.get("symbolRotate").getAsInt());
+        assertEquals(50, json.get("symbolPatternSize").getAsInt());
+    }
+
+    @Test
+    public void testDataOverloads() {
+        assertNotNull(new PictorialBarSeries().setData(new Number[] { 1, 2, 3 }).getData());
+        assertNotNull(new PictorialBarSeries().setData(new Number[][] { { 1, 2 }, { 3, 4 } }).getData());
+        assertNotNull(new PictorialBarSeries().setData(new String[] { "a", "b" }).getData());
+        assertNotNull(new PictorialBarSeries().setData(new PictorialBarDataItem[] {
+                new PictorialBarDataItem().setName("x").setValue(1) }).getData());
+    }
+
+    @Test
+    public void testNullableFieldsAreOmitted() {
+        JsonObject json = SERIALIZER.toJsonTree(new PictorialBarSeries()).getAsJsonObject();
+        assertEquals("pictorialBar", json.get("type").getAsString());
+        assertNull(json.get("symbol"));
+        assertNull(json.get("symbolRepeat"));
+        assertNull(json.get("data"));
+    }
+
+    @Test
+    public void testParsedJsonRoundTrips() {
+        PictorialBarSeries s = new PictorialBarSeries()
+                .setSymbol("circle")
+                .setSymbolRepeat(true)
+                .setData(new Number[] { 1, 2 });
+        JsonElement first = JsonParser.parseString(SERIALIZER.toJson(s));
+        JsonElement second = JsonParser.parseString(SERIALIZER.toJson(s));
+        assertEquals(first, second);
+    }
+
+    @Test
+    public void testChartChainable() {
+        PictorialBar chart = new PictorialBar()
+                .setTitle("Daily Steps")
+                .setLegend()
+                .addXAxis(new String[] { "Mon", "Tue" })
+                .addYAxis()
+                .addSeries(new PictorialBarSeries().setData(new Number[] { 1, 2 }));
+        Option o = chart.getOption();
+        assertNotNull(o.getTitle());
+        assertNotNull(o.getLegend());
+        assertNotNull(o.getSeries());
+    }
+
+    @Test
+    public void testCoordinateSystemSerialization() {
+        JsonObject json = SERIALIZER.toJsonTree(
+                new PictorialBarSeries().setCoordinateSystem("polar")).getAsJsonObject();
+        assertEquals("polar", json.get("coordinateSystem").getAsString());
+    }
+}

--- a/src/test/java/org/icepear/echarts/demo/PictorialBarDemo.java
+++ b/src/test/java/org/icepear/echarts/demo/PictorialBarDemo.java
@@ -1,0 +1,60 @@
+package org.icepear.echarts.demo;
+
+import java.io.FileWriter;
+import java.io.Writer;
+
+import org.icepear.echarts.PictorialBar;
+import org.icepear.echarts.charts.bar.BarItemStyle;
+import org.icepear.echarts.charts.pictorialBar.PictorialBarSeries;
+import org.icepear.echarts.components.title.Title;
+import org.icepear.echarts.components.tooltip.Tooltip;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+/**
+ * Local-only demo: writes /tmp/pictorial-bar-demo.html.
+ *
+ * Run: mvn test -Dtest=PictorialBarDemo
+ * Then: open /tmp/pictorial-bar-demo.html
+ */
+public class PictorialBarDemo {
+
+    @Test
+    public void writeDemoHtml() throws Exception {
+        // Stack of "person" SVG icons whose count tracks daily-steps progress toward 10k goal.
+        String personPath = "path://M19 11h-1V7c0-3.31-2.69-6-6-6S6 3.69 6 7v4H5c-1.1 0-2 .9-2 2v9c0 "
+                + "1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-9c0-1.1-.9-2-2-2zm-7-8c2.21 0 4 1.79 4 4v4h-8V7c0-2.21 1.79-4 4-4z";
+
+        PictorialBar chart = new PictorialBar()
+                .setTitle(new Title().setText("Daily Steps (icons = thousand steps)").setLeft("center"))
+                .setTooltip(new Tooltip().setTrigger("axis"))
+                .addXAxis(new String[] { "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" })
+                .addYAxis(" ")
+                .addSeries(new PictorialBarSeries()
+                        .setName("Steps")
+                        .setSymbol(personPath)
+                        .setSymbolRepeat(true)
+                        .setSymbolSize(new Number[] { 22, 22 })
+                        .setSymbolMargin("10%")
+                        .setSymbolBoundingData(20)
+                        .setSymbolClip(false)
+                        .setItemStyle(new BarItemStyle().setColor("#2f89cf"))
+                        .setData(new Number[] { 8, 9, 12, 7, 14, 18, 15 }));
+
+        String optionJson = new EChartsSerializer().toJson(chart.getOption());
+
+        String html = "<!doctype html><html><head><meta charset='utf-8'><title>PictorialBar Demo</title>"
+                + "<script src='https://cdnjs.cloudflare.com/ajax/libs/echarts/5.4.3/echarts.min.js'></script>"
+                + "<style>html,body,#chart{margin:0;width:100%;height:100vh;background:#f4f6fb}</style>"
+                + "</head><body><div id='chart'></div><script>"
+                + "const chart = echarts.init(document.getElementById('chart'));"
+                + "chart.setOption(" + optionJson + ");"
+                + "window.addEventListener('resize', () => chart.resize());"
+                + "</script></body></html>";
+
+        try (Writer w = new FileWriter("/tmp/pictorial-bar-demo.html")) {
+            w.write(html);
+        }
+        System.out.println("\n>>> Wrote /tmp/pictorial-bar-demo.html — open it in a browser.\n");
+    }
+}

--- a/src/test/java/org/icepear/echarts/render/simple/RenderPictorialBarByChartTest.java
+++ b/src/test/java/org/icepear/echarts/render/simple/RenderPictorialBarByChartTest.java
@@ -1,0 +1,48 @@
+package org.icepear.echarts.render.simple;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.icepear.echarts.Chart;
+import org.icepear.echarts.PictorialBar;
+import org.icepear.echarts.charts.pictorialBar.PictorialBarSeries;
+import org.icepear.echarts.render.Engine;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RenderPictorialBarByChartTest {
+    private Chart<?, ?> chart;
+
+    @Before
+    public void constructChart() {
+        this.chart = new PictorialBar()
+                .setTitle("Daily Steps")
+                .addXAxis(new String[] { "Mon", "Tue", "Wed", "Thu", "Fri" })
+                .addYAxis()
+                .addSeries(new PictorialBarSeries()
+                        .setSymbol("circle")
+                        .setSymbolRepeat(true)
+                        .setSymbolSize(new Number[] { 16, 16 })
+                        .setSymbolMargin("10%")
+                        .setData(new Number[] { 8000, 9500, 12000, 11000, 15000 }));
+    }
+
+    @Test
+    public void testRenderPictorialBarJsonOption() {
+        Engine engine = new Engine();
+        String json = engine.renderJsonOption(chart);
+        assertNotNull(json);
+        assertTrue(json.contains("\"type\":\"pictorialBar\""));
+        assertTrue(json.contains("\"symbolRepeat\":true"));
+        assertTrue(json.contains("\"symbol\":\"circle\""));
+    }
+
+    @Test
+    public void testRenderPictorialBarHtml() {
+        Engine engine = new Engine();
+        String html = engine.renderHtml(chart);
+        assertNotNull(html);
+        assertTrue(html.contains("setOption"));
+        assertTrue(html.contains("\"type\":\"pictorialBar\""));
+    }
+}

--- a/src/test/java/org/icepear/echarts/simple/pictorialBar/BasicPictorialBarTest.java
+++ b/src/test/java/org/icepear/echarts/simple/pictorialBar/BasicPictorialBarTest.java
@@ -1,0 +1,36 @@
+package org.icepear.echarts.simple.pictorialBar;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import org.icepear.echarts.PictorialBar;
+import org.icepear.echarts.charts.pictorialBar.PictorialBarSeries;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.junit.Test;
+
+public class BasicPictorialBarTest {
+
+    @Test
+    public void testBasicPictorialBar() {
+        PictorialBar chart = new PictorialBar()
+                .addXAxis(new String[] { "Mon", "Tue", "Wed", "Thu", "Fri" })
+                .addYAxis()
+                .addSeries(new PictorialBarSeries()
+                        .setSymbol("circle")
+                        .setSymbolRepeat(true)
+                        .setSymbolSize(new Number[] { 16, 16 })
+                        .setSymbolMargin("10%")
+                        .setData(new Number[] { 8000, 9500, 12000, 11000, 15000 }));
+
+        Reader reader = new InputStreamReader(
+                this.getClass().getResourceAsStream("/simple/pictorialBar/basic-pictorial-bar.json"));
+        JsonElement expected = JsonParser.parseReader(reader);
+        JsonElement actual = new EChartsSerializer().toJsonTree(chart.getOption());
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/resources/simple/pictorialBar/basic-pictorial-bar.json
+++ b/src/test/resources/simple/pictorialBar/basic-pictorial-bar.json
@@ -1,0 +1,16 @@
+{
+  "xAxis": [
+    { "type": "category", "data": ["Mon", "Tue", "Wed", "Thu", "Fri"] }
+  ],
+  "yAxis": [{ "type": "value" }],
+  "series": [
+    {
+      "type": "pictorialBar",
+      "data": [8000, 9500, 12000, 11000, 15000],
+      "symbol": "circle",
+      "symbolSize": [16, 16],
+      "symbolRepeat": true,
+      "symbolMargin": "10%"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds the **pictorialBar** series — a bar chart that uses repeated symbols (pictograms) instead of solid rectangles. Standard pick for infographic-style dashboards: icon stacks, progress pictograms, etc.
- Mirrors the existing `Bar` structure (same `CartesianCoordChart` base, same `BaseBarSeriesOption` mixin), and **reuses** `BarItemStyleOption` / `BarLabelOption` since pictorialBar shares those semantics.
- Adds the pictogram-specific symbol fields, with the standard Number/String/Boolean overload pattern. Same fields are also available per-data-item.

## Public API added
- `PictorialBar`
- `charts.pictorialBar.PictorialBarSeries`, `PictorialBarDataItem`, `PictorialBarEmphasis`
- `origin.chart.pictorialBar.PictorialBarSeriesOption`, `PictorialBarStateOption`, `PictorialBarEmphasisOption`, `PictorialBarDataItemOption`

### Pictogram-specific fields
`symbol` (preset name or `path://` SVG), `symbolSize`, `symbolPosition` (`start` / `center` / `end`), `symbolOffset`, `symbolRotate`, `symbolRepeat` (Boolean / Number / String `fixed`), `symbolRepeatDirection`, `symbolMargin`, `symbolClip`, `symbolBoundingData`, `symbolPatternSize`, `hoverAnimation`.

## How to use

### Basic — repeated circles for daily steps

```java
PictorialBar chart = new PictorialBar()
    .addXAxis(new String[] {"Mon", "Tue", "Wed", "Thu", "Fri"})
    .addYAxis()
    .addSeries(new PictorialBarSeries()
        .setSymbol("circle")
        .setSymbolRepeat(true)
        .setSymbolSize(new Number[] {16, 16})
        .setSymbolMargin("10%")
        .setData(new Number[] {8000, 9500, 12000, 11000, 15000}));
```

### Custom SVG path (person icon)

```java
String personPath = "path://M19 11h-1V7c0-3.31-2.69-6-6-6...";

new PictorialBarSeries()
    .setSymbol(personPath)
    .setSymbolRepeat(true)
    .setSymbolSize(new Number[] {22, 22})
    .setSymbolBoundingData(20)         // each icon = 1/20th of the upper bound
    .setItemStyle(new BarItemStyle().setColor("#2f89cf"))
    .setData(new Number[] {8, 9, 12, 7, 14, 18, 15});
```

For the runnable visual demo, see `src/test/java/org/icepear/echarts/demo/PictorialBarDemo.java` — run `mvn test -Dtest=PictorialBarDemo` then `open /tmp/pictorial-bar-demo.html`.

## Tests added (26 new, all passing)
- `simple/pictorialBar/BasicPictorialBarTest` — snapshot
- `charts/pictorialBar/PictorialBarSeriesTest` — 22 unit tests covering every overload (symbolSize Number / Number[] / String / String[]; symbolRepeat Boolean / Number / String; symbolMargin Number / String; symbolBoundingData Number / Number[]), per-data-item symbol overrides, bar-layout passthrough (`barWidth`, `barGap`, `barCategoryGap`, etc.), itemStyle/label nesting, emphasis flags, polar coordinate system, null-omission
- `render/simple/RenderPictorialBarByChartTest` — Engine smoke test
- `demo/PictorialBarDemo` — opt-in HTML writer for visual inspection

## Test plan
- [x] `mvn test -Dtest=BasicPictorialBarTest` — 1/1
- [x] `mvn test -Dtest=PictorialBarSeriesTest` — 22/22
- [x] `mvn test -Dtest=RenderPictorialBarByChartTest` — 2/2
- [x] `mvn test -Dtest=PictorialBarDemo` then `open /tmp/pictorial-bar-demo.html` — pictograms render correctly
- [x] `mvn test` (full suite) — 102 tests, only the 3 pre-existing polar/float-precision failures remain

https://github.com/user-attachments/assets/0d88dfe8-18c8-4bf7-a71f-bbbdd6473c5b

