### PR TITLE
Add JsFunction for tooltip/label formatter callbacks (closes #86)

### DIFF
--- a/src/main/java/org/icepear/echarts/serializer/EChartsSerializer.java
+++ b/src/main/java/org/icepear/echarts/serializer/EChartsSerializer.java
@@ -12,7 +12,8 @@ public class EChartsSerializer {
     public EChartsSerializer(EChartsTypeAdapter<?>... typeAdapters) {
         GsonBuilder gsonBuilder = new GsonBuilder().disableHtmlEscaping()
                 .registerTypeAdapter(markArea2DDataItemAdapter.getType(), markArea2DDataItemAdapter)
-                .registerTypeAdapter(markLine2DDataItemAdapter.getType(), markLine2DDataItemAdapter);
+                .registerTypeAdapter(markLine2DDataItemAdapter.getType(), markLine2DDataItemAdapter)
+                .registerTypeAdapter(JsFunction.class, new JsFunctionTypeAdapter());
         for (EChartsTypeAdapter<?> typeAdapter : typeAdapters) {
             gsonBuilder.registerTypeAdapter(typeAdapter.getType(), typeAdapter);
         }

--- a/src/main/java/org/icepear/echarts/serializer/JsFunction.java
+++ b/src/main/java/org/icepear/echarts/serializer/JsFunction.java
@@ -1,0 +1,71 @@
+package org.icepear.echarts.serializer;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Wraps a JavaScript function literal so it can be embedded into the option
+ * JSON unquoted — i.e. as a real function, not a string.
+ *
+ * <p>ECharts accepts either a string template ({@code "{b}: {c}"}) <em>or</em> a
+ * JS function for fields like {@code tooltip.formatter}, {@code label.formatter},
+ * {@code axisLabel.formatter}, {@code visualMap.formatter}, etc. The string form
+ * already works through any {@code setFormatter(String)} setter; this class
+ * unlocks the function form.
+ *
+ * <p>Pass it through any setter that accepts {@code Object}:
+ * <pre>{@code
+ * tooltip.setFormatter(new JsFunction(
+ *     "function (params) {"
+ *   + "  return '<b>' + params.name + '</b>: ' + params.value + ' (' + params.percent + '%)';"
+ *   + "}"));
+ * }</pre>
+ *
+ * <p><strong>Important:</strong> a {@code JsFunction} is meant to be embedded in
+ * an HTML/JS context (e.g. through {@link org.icepear.echarts.render.Engine}).
+ * The serialized output is valid JavaScript but <em>not</em> strictly valid
+ * JSON, so don't feed it into a JSON parser. The body is emitted verbatim — the
+ * caller is responsible for its JS syntax.
+ */
+public final class JsFunction implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String body;
+
+    public JsFunction(String body) {
+        if (body == null) {
+            throw new IllegalArgumentException("JsFunction body must not be null");
+        }
+        this.body = body;
+    }
+
+    public static JsFunction of(String body) {
+        return new JsFunction(body);
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof JsFunction)) {
+            return false;
+        }
+        return Objects.equals(body, ((JsFunction) o).body);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(body);
+    }
+
+    @Override
+    public String toString() {
+        return "JsFunction{" + body + "}";
+    }
+}

--- a/src/main/java/org/icepear/echarts/serializer/JsFunctionTypeAdapter.java
+++ b/src/main/java/org/icepear/echarts/serializer/JsFunctionTypeAdapter.java
@@ -1,0 +1,39 @@
+package org.icepear.echarts.serializer;
+
+import java.io.IOException;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * Low-level Gson adapter that writes a {@link JsFunction}'s body straight into
+ * the output stream as raw JSON-text — i.e. unquoted. This is what makes the
+ * function survive into the rendered HTML as a real JS callable instead of a
+ * quoted string.
+ *
+ * <p>Implemented as a {@link TypeAdapter} (not a {@code JsonSerializer}) because
+ * only the streaming API exposes {@link JsonWriter#jsonValue(String)}, which
+ * permits raw text. {@code JsonSerializer} can only return a {@code JsonElement}
+ * — and a string element would always come out quoted.
+ *
+ * <p>Read direction is best-effort: if anyone deserializes JS-function-bearing
+ * JSON back into Java (uncommon), they get a {@code JsFunction} wrapping the
+ * raw text. The library only round-trips for tests, so this is rarely exercised.
+ */
+final class JsFunctionTypeAdapter extends TypeAdapter<JsFunction> {
+
+    @Override
+    public void write(JsonWriter out, JsFunction value) throws IOException {
+        if (value == null) {
+            out.nullValue();
+            return;
+        }
+        out.jsonValue(value.getBody());
+    }
+
+    @Override
+    public JsFunction read(JsonReader in) throws IOException {
+        return new JsFunction(in.nextString());
+    }
+}

--- a/src/test/java/org/icepear/echarts/demo/JsFunctionTooltipDemo.java
+++ b/src/test/java/org/icepear/echarts/demo/JsFunctionTooltipDemo.java
@@ -1,0 +1,89 @@
+package org.icepear.echarts.demo;
+
+import java.io.FileWriter;
+import java.io.Writer;
+
+import org.icepear.echarts.Pie;
+import org.icepear.echarts.charts.pie.PieDataItem;
+import org.icepear.echarts.charts.pie.PieSeries;
+import org.icepear.echarts.components.title.Title;
+import org.icepear.echarts.components.tooltip.Tooltip;
+import org.icepear.echarts.serializer.EChartsSerializer;
+import org.icepear.echarts.serializer.JsFunction;
+import org.junit.Test;
+
+/**
+ * Local-only demo: writes /tmp/js-function-tooltip-demo.html.
+ *
+ * Hover over a slice to see the rich tooltip rendered by the JS function
+ * built in Java via {@link JsFunction}. This is the visual proof for issue #86.
+ *
+ * Run: mvn test -Dtest=JsFunctionTooltipDemo
+ * Then: open /tmp/js-function-tooltip-demo.html
+ */
+public class JsFunctionTooltipDemo {
+
+    @Test
+    public void writeDemoHtml() throws Exception {
+        // The exact JS shape the issue requested — multi-line HTML built from
+        // params.marker / params.name / params.value / params.percent.
+        JsFunction tooltipFormatter = new JsFunction(
+                "function (params) {\n"
+              + "  return ''\n"
+              + "    + '<div class=\"tooltip-content\">'\n"
+              + "    + '  ' + params.marker\n"
+              + "    + '  <p class=\"tooltip-category\">' + params.name + '</p>'\n"
+              + "    + '  <p class=\"tooltip-value\">' + params.value.toLocaleString() + '</p>'\n"
+              + "    + '  <p class=\"tooltip-currency\">MDL</p>'\n"
+              + "    + '  <div class=\"tooltip-percent\">' + params.percent + '%</div>'\n"
+              + "    + '</div>';\n"
+              + "}");
+
+        Pie chart = new Pie()
+                .setTitle(new Title()
+                        .setText("Quarterly Revenue by Region")
+                        .setLeft("center"))
+                .setTooltip(new Tooltip()
+                        .setTrigger("item")
+                        .setBackgroundColor("rgba(20, 24, 32, 0.92)")
+                        .setBorderColor("#3a4a66")
+                        .setFormatter((Object) tooltipFormatter))
+                .setLegend()
+                .addSeries(new PieSeries()
+                        .setName("Revenue")
+                        .setRadius(new String[] { "40%", "65%" })
+                        .setData(new PieDataItem[] {
+                                new PieDataItem().setName("North").setValue(1248000),
+                                new PieDataItem().setName("South").setValue(958500),
+                                new PieDataItem().setName("East").setValue(742300),
+                                new PieDataItem().setName("West").setValue(1102400),
+                                new PieDataItem().setName("Central").setValue(615000)
+                        }));
+
+        String optionJson = new EChartsSerializer().toJson(chart.getOption());
+
+        String html = "<!doctype html><html><head><meta charset='utf-8'>"
+                + "<title>JsFunction Tooltip Demo (issue #86)</title>"
+                + "<script src='https://cdnjs.cloudflare.com/ajax/libs/echarts/5.4.3/echarts.min.js'></script>"
+                + "<style>"
+                + "  html, body, #chart { margin: 0; width: 100%; height: 100vh; background: #0b1220; }"
+                + "  .tooltip-content { color: #fff; font-family: -apple-system, sans-serif; min-width: 180px; }"
+                + "  .tooltip-content p { margin: 4px 0; }"
+                + "  .tooltip-category { font-size: 14px; font-weight: 600; color: #e8eef9; }"
+                + "  .tooltip-value    { font-size: 22px; font-weight: 700; color: #ffd166; }"
+                + "  .tooltip-currency { font-size: 11px; color: #8aa0c2; letter-spacing: .1em; }"
+                + "  .tooltip-percent  { margin-top: 6px; padding: 3px 8px; background: #2a4a82;"
+                + "                      border-radius: 12px; display: inline-block; font-size: 12px; }"
+                + "</style></head><body><div id='chart'></div>"
+                + "<script>"
+                + "  const chart = echarts.init(document.getElementById('chart'), 'dark');"
+                + "  chart.setOption(" + optionJson + ");"
+                + "  window.addEventListener('resize', () => chart.resize());"
+                + "</script></body></html>";
+
+        try (Writer w = new FileWriter("/tmp/js-function-tooltip-demo.html")) {
+            w.write(html);
+        }
+        System.out.println("\n>>> Wrote /tmp/js-function-tooltip-demo.html — open it and hover over a slice.\n");
+    }
+}

--- a/src/test/java/org/icepear/echarts/serializer/JsFunctionTest.java
+++ b/src/test/java/org/icepear/echarts/serializer/JsFunctionTest.java
@@ -1,0 +1,231 @@
+package org.icepear.echarts.serializer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.icepear.echarts.Bar;
+import org.icepear.echarts.Pie;
+import org.icepear.echarts.charts.pie.PieDataItem;
+import org.icepear.echarts.charts.pie.PieSeries;
+import org.icepear.echarts.components.tooltip.Tooltip;
+import org.junit.Test;
+
+/**
+ * Verifies the JsFunction value class and — crucially — that the registered
+ * TypeAdapter writes the body unquoted into the JSON stream so it survives
+ * into the rendered HTML as a real JavaScript function.
+ */
+public class JsFunctionTest {
+
+    private static final EChartsSerializer SERIALIZER = new EChartsSerializer();
+
+    // -- value class behavior ------------------------------------------------
+
+    @Test
+    public void testGetterReturnsBody() {
+        JsFunction f = new JsFunction("function (p) { return p.value; }");
+        assertEquals("function (p) { return p.value; }", f.getBody());
+    }
+
+    @Test
+    public void testStaticFactoryEqualsConstructor() {
+        assertEquals(new JsFunction("x"), JsFunction.of("x"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullBodyRejected() {
+        new JsFunction(null);
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        JsFunction a = new JsFunction("function () { return 1; }");
+        JsFunction b = new JsFunction("function () { return 1; }");
+        JsFunction c = new JsFunction("function () { return 2; }");
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+        assertNotEquals(a, null);
+        assertNotEquals(a, "function () { return 1; }");
+    }
+
+    @Test
+    public void testToStringIncludesBody() {
+        assertTrue(new JsFunction("function(){return 42;}").toString().contains("function(){return 42;}"));
+    }
+
+    // -- serialization: the critical "unquoted" behavior --------------------
+
+    @Test
+    public void testTopLevelSerializationIsUnquoted() {
+        String json = SERIALIZER.toJson(new JsFunction("function (p) { return p.value; }"));
+        // No surrounding quotes — the body is emitted verbatim as JS.
+        assertEquals("function (p) { return p.value; }", json);
+        assertFalse("must not be quoted", json.startsWith("\""));
+        assertFalse("must not be quoted", json.endsWith("\""));
+    }
+
+    @Test
+    public void testNestedInsideObjectIsUnquoted() {
+        Map<String, Object> wrapper = new HashMap<>();
+        wrapper.put("formatter", new JsFunction("function(p){return p.name;}"));
+        String json = SERIALIZER.toJson(wrapper);
+        // Key is quoted; value is not.
+        assertEquals("{\"formatter\":function(p){return p.name;}}", json);
+    }
+
+    @Test
+    public void testStringFormatterStillQuoted() {
+        // Sanity check: the existing String overload is untouched. A plain string
+        // formatter must remain a JSON string.
+        Map<String, Object> wrapper = new HashMap<>();
+        wrapper.put("formatter", "{b}: {c}");
+        assertEquals("{\"formatter\":\"{b}: {c}\"}", SERIALIZER.toJson(wrapper));
+    }
+
+    @Test
+    public void testNullSerializesToJsonNull() {
+        Map<String, Object> wrapper = new HashMap<>();
+        wrapper.put("formatter", null);
+        // Default Gson behavior: null fields are omitted from objects.
+        assertEquals("{}", SERIALIZER.toJson(wrapper));
+    }
+
+    @Test
+    public void testNullJsFunctionWrittenAsNullInArray() {
+        // When the field can't be omitted (array context), null becomes JSON null.
+        Object[] arr = new Object[] { new JsFunction("function(){return 1;}"), null };
+        String json = SERIALIZER.toJson(arr);
+        assertTrue(json, json.contains("function(){return 1;}"));
+        assertTrue(json, json.contains("null"));
+    }
+
+    @Test
+    public void testMultilineBodyPreservedExactly() {
+        String body = "function (params) {\n"
+                + "  if (params.value > 100) {\n"
+                + "    return 'big: ' + params.value;\n"
+                + "  }\n"
+                + "  return 'small: ' + params.value;\n"
+                + "}";
+        Map<String, Object> wrapper = new HashMap<>();
+        wrapper.put("formatter", new JsFunction(body));
+        String json = SERIALIZER.toJson(wrapper);
+        assertTrue("multiline body must survive intact", json.contains(body));
+    }
+
+    @Test
+    public void testHtmlEscapingDisabledForJsFunctionBody() {
+        // Critical: < and > must NOT be escaped to < / > — otherwise the
+        // emitted JS won't contain literal HTML tags. EChartsSerializer disables
+        // HTML escaping globally, but verify it specifically for JsFunction bodies.
+        String body = "function(p){return '<b>' + p.name + '</b>';}";
+        String json = SERIALIZER.toJson(new JsFunction(body));
+        assertTrue(json.contains("<b>"));
+        assertTrue(json.contains("</b>"));
+        assertFalse(json.contains("\\u003c"));
+    }
+
+    @Test
+    public void testCustomEChartsSerializerStillRegistersJsFunctionAdapter() {
+        // The adapter should be registered even when the user passes additional
+        // type adapters via the varargs constructor.
+        EChartsSerializer custom = new EChartsSerializer();
+        String json = custom.toJson(new JsFunction("function(){}"));
+        assertEquals("function(){}", json);
+    }
+
+    // -- end-to-end: through a real Tooltip on a real chart -----------------
+
+    @Test
+    public void testTooltipFormatterEndToEndWithPie() {
+        JsFunction formatter = new JsFunction(
+                "function (p) { return p.name + ': ' + p.value + ' (' + p.percent + '%)'; }");
+
+        Pie pie = new Pie()
+                .setTooltip(new Tooltip().setTrigger("item").setFormatter((Object) formatter))
+                .addSeries(new PieSeries()
+                        .setRadius("60%")
+                        .setData(new PieDataItem[] {
+                                new PieDataItem().setName("A").setValue(40),
+                                new PieDataItem().setName("B").setValue(60)
+                        }));
+
+        String json = SERIALIZER.toJson(pie.getOption());
+        assertNotNull(json);
+        // Function literal lives inside the tooltip object, unquoted.
+        assertTrue(json, json.contains("\"formatter\":function (p)"));
+        assertFalse("formatter must not be wrapped in quotes",
+                json.contains("\"formatter\":\"function"));
+    }
+
+    @Test
+    public void testTooltipFormatterEndToEndWithBar() {
+        Bar bar = new Bar()
+                .addXAxis(new String[] { "Mon", "Tue", "Wed" })
+                .addYAxis()
+                .setTooltip(new Tooltip().setTrigger("axis").setFormatter((Object) new JsFunction(
+                        "function(arr){return arr.map(function(p){return p.seriesName + ': ' + p.value;}).join('<br/>');}")))
+                .addSeries(new Number[] { 1, 2, 3 });
+
+        String json = SERIALIZER.toJson(bar.getOption());
+        assertTrue(json, json.contains("\"formatter\":function(arr)"));
+        assertFalse(json.contains("\"formatter\":\"function"));
+    }
+
+    @Test
+    public void testFormatterOutputIsValidJavascriptWhenEmbedded() {
+        // Simulate the rendering pipeline: build the option, get the JSON,
+        // wrap in `var option = …;` — this must produce evaluable JS, not JSON.
+        Tooltip t = new Tooltip().setFormatter((Object) new JsFunction("function(p){return p.value;}"));
+        String json = SERIALIZER.toJson(t);
+        String simulatedScript = "var option = " + json + ";";
+        // Must contain an unquoted `function` token immediately after the colon.
+        int idx = simulatedScript.indexOf("\"formatter\":");
+        assertNotEquals(-1, idx);
+        char nextNonSpace = ' ';
+        for (int i = idx + "\"formatter\":".length(); i < simulatedScript.length(); i++) {
+            char ch = simulatedScript.charAt(i);
+            if (!Character.isWhitespace(ch)) {
+                nextNonSpace = ch;
+                break;
+            }
+        }
+        assertEquals("formatter value must start with `f` (function), not `\"`", 'f', nextNonSpace);
+    }
+
+    // -- read direction (best-effort, for round-trip support) ---------------
+
+    @Test
+    public void testReadDirectionThroughGson() {
+        // Round-trip a string into JsFunction (best-effort symmetric path).
+        com.google.gson.Gson gson = new com.google.gson.GsonBuilder()
+                .registerTypeAdapter(JsFunction.class, new JsFunctionTypeAdapter())
+                .create();
+        JsFunction f = gson.fromJson("\"function(){return 1;}\"", JsFunction.class);
+        assertNotNull(f);
+        assertEquals("function(){return 1;}", f.getBody());
+    }
+
+    @Test
+    public void testInvalidJsBodyIsCallerResponsibility() {
+        // We don't validate the body — garbage in, garbage-but-emitted out. The
+        // browser surfaces the syntax error. Document intent here so future
+        // maintainers don't add server-side validation by mistake.
+        try {
+            String json = SERIALIZER.toJson(new JsFunction("not actually javascript ::: ;;;"));
+            assertNotNull(json);
+            // We just verify that toJson doesn't throw — invalid syntax is a JS-side concern.
+        } catch (Exception e) {
+            fail("Body validation should be the browser's job, not the serializer's: " + e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #86 — adds the ability to define a tooltip (or label / axis-label / visualMap) formatter as a real JavaScript function built in Java, matching the JS API shown in the issue:

```js
tooltip: {
  formatter(params) {
    return '<div>' + params.name + ': ' + params.value + ' (' + params.percent + '%)</div>';
  }
}
```

The string-template form (`"{b}: {c}"`) already worked through the existing `setFormatter(String)` overloads. The function form was unreachable because Gson serialized any `Object` formatter as a quoted JSON string — the rendered HTML would contain a string, not a callable function.

## How it works

A new `JsFunction` value class wraps a JS body. A low-level Gson `TypeAdapter` uses `JsonWriter#jsonValue(String)` to emit the body **straight into the output stream, unquoted**. When the option JSON is dropped into the rendered `<script>` tag (`Engine` uses Handlebars triple-braces, so no HTML-escaping), the function survives as a real JS callable.

The adapter is registered automatically in `EChartsSerializer`'s constructor — no new public surface beyond `JsFunction` itself.

## How to use

```java
import org.icepear.echarts.serializer.JsFunction;

JsFunction formatter = new JsFunction(
    "function(p) { return p.name + ': ' + p.value + ' (' + p.percent + '%)'; }");

new Pie()
    .setTooltip(new Tooltip().setTrigger("item").setFormatter((Object) formatter))
    .addSeries(/* ... */);
```

The `(Object)` cast picks the existing `setFormatter(Object)` overload over `setFormatter(String)`. Same pattern works on `SeriesLabel`, `AxisLabel` variants, `PieLabel`, and any other class with an `Object`-typed formatter.

For multi-line bodies just concatenate strings — newlines are preserved verbatim:

```java
new JsFunction(
    "function(p) {"
  + "  return '<b>' + p.name + '</b>: ' + p.value;"
  + "}");
```

> ⚠️ **Important:** `JsFunction`-bearing output is meant for embedding in HTML/JS. The result is valid JavaScript but **not** strictly valid JSON — don't feed it into a JSON parser. Body validation is the browser's job; garbage syntax surfaces as a JS error in the console.

## Tests added (18 new, all passing)

`serializer/JsFunctionTest` covers:
- Value class — equals/hashCode, null-body rejection, static factory parity
- **Unquoted-output invariant** — top-level, nested in object, nested in array
- String formatters remain quoted (no regression)
- Multi-line bodies preserved exactly
- HTML `<tag>` characters preserved (HTML escaping stays disabled, critical for tooltip markup)
- End-to-end through Tooltip on Pie and Bar
- Sanity check that the embedded result starts with `f` (function), not `"`
- Read direction (best-effort symmetric round-trip)
- Body-validation is explicitly out-of-scope and won't throw

## Visual demo

`src/test/java/org/icepear/echarts/demo/JsFunctionTooltipDemo.java` builds a richer multi-element tooltip (using `params.marker`, `params.name`, `params.value`, `params.percent`) on a Pie chart and writes a self-contained dark-themed HTML to `/tmp/js-function-tooltip-demo.html`.

```bash
mvn test -Dtest=JsFunctionTooltipDemo
open /tmp/js-function-tooltip-demo.html
# Hover over a slice — the rich HTML tooltip is rendered by the JS function built in Java.
```

## Test plan
- [x] `mvn test -Dtest=JsFunctionTest` — 18/18 pass
- [x] `mvn test -Dtest=JsFunctionTooltipDemo` — writes demo file
- [x] `open /tmp/js-function-tooltip-demo.html` — tooltip renders with rich HTML on hover; verified the rendered HTML contains `"formatter":function (params) {` (unquoted)
- [x] `mvn test` (full suite) — 95 tests, only the 3 pre-existing polar/float-precision failures remain on `master`

https://github.com/user-attachments/assets/0132c7cd-c768-4d2f-af94-1b613f57efeb